### PR TITLE
DOCS-3226 General fixes

### DIFF
--- a/modules/ROOT/pages/enable-inbound-traffic.adoc
+++ b/modules/ROOT/pages/enable-inbound-traffic.adoc
@@ -26,7 +26,12 @@ All inbound traffic entering Anypoint Runtime Fabric is encrypted using TLS. Thi
 .. In the Runtime Manager tab, give yourself the “Manage Runtime Fabrics” permission for your Runtime Fabric environment.
 .. In the Secrets Manager tab, give yourself the “Manage Secret Groups”, “Write Secrets”, and “Read Secrets Metadata” permissions for your Runtime Fabric environment.
 . You’ll need a certificate-key pair for the internal load balancer in Runtime Fabric. If you have one already, both files must be of the .pem type, your keystore must have a passcode, and your Common Name should match the domain you’ll use in your Runtime Fabric. Otherwise, follow these steps to generate one for evaluation purposes:
-.. Run the following command on your machine to begin generating a certificate-key pair: `openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365`
+.. Run the following command on your machine to begin generating a certificate-key pair: 
++
+----
+openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365
+----
++
 .. Type a passphrase for your key.
 .. Fill out the requested information (Country, State, etc). When you’re asked for a Common Name, supply the domain you’ll use in your Runtime Fabric.
 +
@@ -77,7 +82,7 @@ _Note: If your secrets group doesn’t appear, make sure you have the “Manage 
 +
 .. In the TLS Context menu, select the TLS Context to be used for your Runtime Fabric.
 +
-_Note: If a wildcard certificate is used (for example, *.example.com), each application URL would take the format of *{app-name}.example.com* Otherwise, the application URL will be in the format of example.com/{app-name}._
+_Note: If a wildcard certificate is used (for example, *.example.com), each application URL would take the format of {app-name}.example.com. Otherwise, the application URL will be in the format of example.com/{app-name}._
 +
 . Click the Deploy button to begin the deployment on Runtime Fabric. A toast message should appear in the bottom-right of the page to indicate a successful response. The deployment may take up to a minute. You can see its status toward the top of the form. When the status transitions to “Applied”, the internal load balancer is successfully deployed and inbound traffic has been enabled.
 
@@ -85,8 +90,18 @@ _Note: If a wildcard certificate is used (for example, *.example.com), each appl
 
 To resolve the Common Name (CN) to applications deployed on Runtime Fabric, DNS will need to be configured to map the CN to the IP address of the external load balancer or of each controller VM. To test inbound traffic for enabled applications before configuring DNS, a request can be sent using the IP address along with a host header set to the domain. The structure of the domain depends on whether a wildcard was used in your certificate.
 
-* A CN with a wildcard (e.g. \*.example.com) will use the following request header format: `Host: {app-name}.example.com`. Here’s an example cURL command to verify: `curl -Lvk -XGET https://{ip-address}/{path} -H 'Host: {app-name}.example.com'`
-* A CN without a wildcard (e.g. example.com) will will use the following request header format: `Host: example.com`. Here’s an example cURL command to verify: `curl -Lvk -XGET https://{ip-address}/{app-name}/{path} -H 'Host: example.com'`
+* A CN with a wildcard (e.g. *.example.com) will use the following request header format: `Host: {app-name}.example.com`. Here’s an example cURL command to verify: 
++
+----
+curl -Lvk -XGET https://{ip-address}/{path} -H 'Host: {app-name}.example.com'
+----
++
+* A CN without a wildcard (e.g. example.com) will will use the following request header format: `Host: example.com`. Here’s an example cURL command to verify: 
++
+----
+curl -Lvk -XGET https://{ip-address}/{app-name}/{path} -H 'Host: example.com'`
+----
++
 
 == Next Steps
 

--- a/modules/ROOT/pages/enable-inbound-traffic.adoc
+++ b/modules/ROOT/pages/enable-inbound-traffic.adoc
@@ -37,7 +37,12 @@ openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365
 +
 _Note: If you use a wildcard (e.g. *.example.com) in your Common Name, your application URLs will use the following format: `{app-name}.example.com`. Otherwise, your application URLs will use this format: `example.com/{app-name}`._
 +
-
+[NOTE]
+The internal load balancer is configured to attach to a network interface named "eth0". Ensure the desired network interface is named appropriately for each controller VM. This can be verified by running the following command on each controller VM:
++
+----
+ifconfig | grep eth0
+----
 
 == Create a TLS Context
 

--- a/modules/ROOT/pages/enable-inbound-traffic.adoc
+++ b/modules/ROOT/pages/enable-inbound-traffic.adoc
@@ -26,7 +26,7 @@ All inbound traffic entering Anypoint Runtime Fabric is encrypted using TLS. Thi
 .. In the Runtime Manager tab, give yourself the “Manage Runtime Fabrics” permission for your Runtime Fabric environment.
 .. In the Secrets Manager tab, give yourself the “Manage Secret Groups”, “Write Secrets”, and “Read Secrets Metadata” permissions for your Runtime Fabric environment.
 . You’ll need a certificate-key pair for the internal load balancer in Runtime Fabric. If you have one already, both files must be of the .pem type, your keystore must have a passcode, and your Common Name should match the domain you’ll use in your Runtime Fabric. Otherwise, follow these steps to generate one for evaluation purposes:
-.. Run the following command on your machine to begin generating a certificate-key pair: 
+.. Run the following command on your machine to generate a certificate-key pair: 
 +
 ----
 openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365

--- a/modules/ROOT/pages/install-aws.adoc
+++ b/modules/ROOT/pages/install-aws.adoc
@@ -27,7 +27,7 @@ In addition, ensure the following criteria have been met before beginning the in
 The installer script zip file includes the necessary scripts needed to install Runtime Fabric.
 
 [NOTE]
-If you're unable to follow these steps, please reach out to your Customer Success Manager for more information on how to get Anypoint Runtime Fabric enabled for your account.
+If you're unable to follow these steps, contact your Customer Success Manager for more information on how to get Anypoint Runtime Fabric enabled for your account.
 
 . Log in to Anypoint platform and navigate to Runtime Manager.
 . On the left navigation pane, select "Runtime Fabrics".
@@ -69,7 +69,7 @@ Some of the values for the variables below are available on the Create Runtime F
 | `installer_url` | The URL of the Runtime Fabric installation package, available on the Create Runtime Fabric page. | `runtime-fabric.s3.amazonaws.com/...`
 | `controllers` | The number of controller VMs to provision. | `3`
 | `workers` | The number of worker VMs to provision. | `3`
-| `mule_license` | The digest (`muleLicenseKey.lic`) of your organization's Mule Enterprise license key. Learn more on how to xref:3.9@mule-runtime::installing-an-enterprise-license.adoc[install a Mule Enterprise license]. |
+| `mule_license` | A base64 encoded string of your organization's Mule Enterprise license key (`license.lic`). |
 
 |===
 
@@ -159,7 +159,7 @@ The installer VM will download the installer package, unpack it and begin instal
 
 When installation has been completed, a cluster will be formed across all VMs. The installer VM will then carry out the registration step using the Anypoint Organization ID, token, and region specified.
 
-After registration has completed, you'll see Runtime Fabric in Anypoint Runtime Manager, under the Runtime Fabrics tab. The installation script on the installer VM will proceed to insert the Mule Enterprise license digest in Runtime Fabric.
+After registration has completed, you'll see Runtime Fabric in Anypoint Runtime Manager, under the Runtime Fabrics tab. The installation script on the installer VM will proceed to insert the Mule Enterprise license key in Runtime Fabric.
 
 When finished, verify the installation by running this command to view the health of the Runtime Fabric cluster on any VM:
 ----
@@ -186,6 +186,10 @@ tail -f /var/log/rtf-init.log
 You can tail the same log on each VM to view its progress.
 
 When the installation completes successfully, the file `/opt/anypoint/runtimefabric/init-succeeded` is created.
+
+=== Access to Ops Center
+
+After installation is completed successfully, the last few lines of the log output file located at `/var/log/rtf-init.log` will contain a host, username, and password to access the Ops Center. Copy these values and store them securely.
 
 == Next Steps
 

--- a/modules/ROOT/pages/install-aws.adoc
+++ b/modules/ROOT/pages/install-aws.adoc
@@ -69,7 +69,7 @@ Some of the values for the variables below are available on the Create Runtime F
 | `installer_url` | The URL of the Runtime Fabric installation package, available on the Create Runtime Fabric page. | `runtime-fabric.s3.amazonaws.com/...`
 | `controllers` | The number of controller VMs to provision. | `3`
 | `workers` | The number of worker VMs to provision. | `3`
-| `mule_license` | A base64 encoded string of your organization's Mule Enterprise license key (`license.lic`). |
+| `mule_license` | A base64 encoded content of your organization's Mule Enterprise license key (`license.lic`). |
 
 |===
 
@@ -185,7 +185,7 @@ tail -f /var/log/rtf-init.log
 [NOTE]
 You can tail the same log on each VM to view its progress.
 
-When the installation completes successfully, the file `/opt/anypoint/runtimefabric/init-succeeded` is created.
+When the installation completes successfully, the file `/opt/anypoint/runtimefabric/.state/init-complete` is created.
 
 === Access to Ops Center
 

--- a/modules/ROOT/pages/install-aws.adoc
+++ b/modules/ROOT/pages/install-aws.adoc
@@ -69,7 +69,7 @@ Some of the values for the variables below are available on the Create Runtime F
 | `installer_url` | The URL of the Runtime Fabric installation package, available on the Create Runtime Fabric page. | `runtime-fabric.s3.amazonaws.com/...`
 | `controllers` | The number of controller VMs to provision. | `3`
 | `workers` | The number of worker VMs to provision. | `3`
-| `mule_license` | A base64 encoded content of your organization's Mule Enterprise license key (`license.lic`). |
+| `mule_license` | The base64 encoded contents of your organization's Mule Enterprise license key (`license.lic`). |
 
 |===
 

--- a/modules/ROOT/pages/install-azure.adoc
+++ b/modules/ROOT/pages/install-azure.adoc
@@ -164,6 +164,10 @@ You can tail the same log on each VM to view its progress.
 
 When the installation completes successfully, the file `/opt/anypoint/runtimefabric/init-succeeded` is created.
 
+=== Access to Ops Center
+
+After installation is completed successfully, the last few lines of the log output file located at `/var/log/rtf-init.log` will contain a host, username, and password to access the Ops Center. Copy these values and store them securely.
+
 == Next Steps
 
 Before deploying applications on Anypoint Runtime Fabric, you'll need to perform the following steps:

--- a/modules/ROOT/pages/install-azure.adoc
+++ b/modules/ROOT/pages/install-azure.adoc
@@ -56,7 +56,7 @@ RTF_MULE_LICENSE='' \
 ./generate-templates.sh
 ----
 +
-* Using the terminal, convert the Mule Enterprise license key to base64, and paste as the value for `RTF_MULE_LICENSE` in the text editor.
+* Using the terminal, convert the Mule Enterprise license key to base64, and paste the contents as the value for `RTF_MULE_LICENSE` in the text editor.
 +
 ----
 base64 -b0 license.lic

--- a/modules/ROOT/pages/install-azure.adoc
+++ b/modules/ROOT/pages/install-azure.adoc
@@ -162,7 +162,7 @@ tail -f /var/log/rtf-init.log
 [NOTE]
 You can tail the same log on each VM to view its progress.
 
-When the installation completes successfully, the file `/opt/anypoint/runtimefabric/init-succeeded` is created.
+When the installation completes successfully, the file `/opt/anypoint/runtimefabric/.state/init-complete` is created.
 
 === Access to Ops Center
 

--- a/modules/ROOT/pages/install-azure.adoc
+++ b/modules/ROOT/pages/install-azure.adoc
@@ -25,7 +25,7 @@ Prepare the necessary steps and understand the core concepts prior to installing
 The installer script ZIP file includes the necessary scripts needed to install Runtime Fabric on Azure.
 
 [NOTE]
-If you're unable to follow these steps, please reach out to your Customer Success Manager for more information on how to get Anypoint Runtime Fabric enabled for your account.
+If you're unable to follow these steps, contact your Customer Success Manager for more information on how to get Anypoint Runtime Fabric enabled for your account.
 
 . Log in to Anypoint platform and navigate to Runtime Manager.
 . On the left navigation pane, select "Runtime Fabrics".
@@ -41,23 +41,28 @@ You'll find a directory named `azure` containing the following:
 
 == Provision Infrastructure
 
-First, the ARM templates will need to be generated to include the initialization script and Mule Enterprise license. The resulting templates will then be used to provision the infrastructure needed. The embedded script will automatically begin the process on each VM to install and register Runtime Fabric.
+First, the ARM templates will need to be generated to include the initialization script and Mule Enterprise license. The resulting templates will then be used to provision the infrastructure needed. The embedded script will automatically begin the process to install and register Runtime Fabric on each VM.
 
 === Prepare ARM Templates
 
 The included Azure Resource Manager template files describe the required hardware and network settings needed to install and operate Runtime Fabric on Azure. Follow these steps to insert your organization's Mule Enterprise license key and initialization script (located in `scripts/init.sh`). If you're using Windows, you'll need a shell terminal emulator (such as cygwin) or access to a Unix-based computer to follow these steps:
 
-. Follow the steps to xref:3.9@mule-runtime::installing-an-enterprise-license.adoc[install your Mule Enterprise license] and save the generated `muleLicenseKey.lic` file.
+. Obtain your Mule Enterprise license key file and transfer to your Unix environment if necessary.
 . Open a terminal/shell and navigate to the `azure` directory of the unzipped scripts.
-. Run the following command to generate the ARM templates. It may be easier to use a text editor to prepare the script before running it:
+. Copy the command below in a text editor to make it easier to add in the Mule Enterprise license before running:
 +
 ----
 RTF_MULE_LICENSE='' \
 ./generate-templates.sh
 ----
 +
-* The Mule License contents should be XML, and should be surrounded in single quotes when passed in the script.
+* Using the terminal, convert the Mule Enterprise license key to base64, and paste as the value for `RTF_MULE_LICENSE` in the text editor.
 +
+----
+base64 -b0 license.lic
+----
++
+. Copy the command from the text editor and run it in the terminal on the `azure` directory.
 . Confirm the output of the `ARM-template-dev.json` and `ARM-template-prod.json` files in the `azure` directory.
 
 === Deploy using ARM Template

--- a/modules/ROOT/pages/install-manual.adoc
+++ b/modules/ROOT/pages/install-manual.adoc
@@ -30,8 +30,7 @@ If you're unable to follow these steps, contact your Customer Success Manager fo
 . Log in to Anypoint platform and navigate to Runtime Manager.
 . On the left navigation pane, select "Runtime Fabrics".
 . Click "Create Runtime Fabric".
-. Copy the "Download files" link.
-.. Right-click the button and select an option most similar to "Copy link location".
+. Right-click the "Download files" button and select an option most similar to "Copy link location".
 . Download the file to the installer VM.
 .. Open a shell (SSH session) to the installer VM.
 .. Download the file: `curl {INSTALLER_URL} --output rtf-install-scripts.zip`
@@ -71,32 +70,37 @@ To begin, we will run a configuration tool. This aids in generating the environm
 | `RTF_ENDPOINT` | The Anypoint control plane you're registering to, available on the Create Runtime Fabric page. | `anypoint.mulesoft.com`
 | `RTF_INSTALL_PACKAGE_URL` | The URL of the Runtime Fabric installation package, available on the Create Runtime Fabric page. _If this is not specified, the installer will expect you to manually copy the installation package to_ `/opt/anypoint/runtimefabric/installer.tar.gz`. | `https://s3.amazonaws.com/runtimefabric/...`
 | `RTF_NAME` | The name of your Runtime Fabric cluster. | `runtime-fabric`
-| `RTF_TOKEN` | The token used to join each other VM to the installer VM. This should be a unique value to avoid conflicts during installation. | `my-rtf-token`
-| `RTF_MULE_LICENSE` | The digest contents (`muleLicenseKey.lic`) of your organization's Mule Enterprise license key. Learn more on how to xref:3.9@mule-runtime::installing-an-enterprise-license.adoc[install a Mule Enterprise license]. | `<xml>...`
+| `RTF_MULE_LICENSE` | A base64 encoded value of the Mule Enterprise license key binary file obtained from MuleSoft. | `==ABCD12934...`
+| `RTF_TOKEN` | Optional. The token used to join each other VM to the installer VM. This should be a unique value to avoid conflicts during installation. | `my-rtf-token`
+| `RTF_HTTP_PROXY` | Optional. A hostname and port for a HTTP proxy server to forward outbound HTTP requests. | `1.1.1.1:80`
+| `RTF_TCP_PROXY` | Optional. A hostname and port for a TCP proxy server to forward outbound TCP requests. | `1.1.1.2:800`
+| `RTF_NO_PROXY` | Optional. A comma-separated list of hosts which should bypass the proxy. | `1.1.1.1,no-proxy.com`
+| `RTF_SERVICE_UID` | Optional. An integer representing the user ID to run each Runtime Fabric service. Overrides the default behavior of creating a user named "planet". | `1000`
+| `RTF_SERVICE_GID` | Optional. An integer representing the group ID used when running each Runtime Fabric service. Overrides the default behavior of creating a group named "planet". | `900`
 |===
 
 [NOTE]
 To help identify the block device paths to your disks, run the `lsblk` command on the VMs.
 
 . If needed, open a shell/SSH on the installer VM and navigate to the `manual` directory from the unzipped directory.
-. Fill in the values to each variable and execute `generate-configs.sh`. It may be easier to paste the following command in a text editor to fill in the variables.
+. Copy the command below in a text editor to aid in filling in each of the variables.
 +
 ----
 RTF_CONTROLLER_IPS='' \
 RTF_WORKER_IPS='' \
-RTF_DOCKER_DEVICE= \
-RTF_ETCD_DEVICE= \
+RTF_DOCKER_DEVICE='' \
+RTF_ETCD_DEVICE='' \
 RTF_AUTH_TOKEN='' \
-RTF_REGION= \
-RTF_ORG_ID= \
-RTF_ENDPOINT= \
-RTF_INSTALL_PACKAGE_URL= \
-RTF_NAME= \
-RTF_TOKEN= \
+RTF_REGION='' \
+RTF_ORG_ID='' \
+RTF_ENDPOINT='' \
+RTF_INSTALL_PACKAGE_URL='' \
+RTF_NAME='' \
 RTF_MULE_LICENSE='' \
 ./generate-configs.sh
 ----
 +
+. Run the command with all values filled in and run it on the installer VM.
 . The output is a configuration snippet for the `installer`, `controller`, and `worker` VMs. Execute the snippet on each VM based on its desired role to add the expected environment variables.
 
 .. On the installer VM, paste and execute the `installer` snippet to prepare it for the installation script.

--- a/modules/ROOT/pages/install-manual.adoc
+++ b/modules/ROOT/pages/install-manual.adoc
@@ -101,12 +101,7 @@ RTF_MULE_LICENSE='' \
 ----
 +
 . Run the command with all values filled in and run it on the installer VM.
-. The output is a configuration snippet for the `installer`, `controller`, and `worker` VMs. Execute the snippet on each VM based on its desired role to add the expected environment variables.
-
-.. On the installer VM, paste and execute the `installer` snippet to prepare it for the installation script.
-.. On the controller VM(s), paste and execute the `controller` snippet.
-.. On the worker VMs, paste and execute the `worker` snippet.
-
+. The output is a configuration snippet for each IP address specified. Execute the snippet on each VM based upon its IP address to apply the expected environment variables.
 . On each VM, copy the `installer/scripts/init.sh` file to `/opt/anypoint/runtimefabric`, and ensure the script is executable. The script below assumes the present working directory contains the unzipped directory `rtf-install-scripts`.
 
 ----

--- a/modules/ROOT/pages/install-manual.adoc
+++ b/modules/ROOT/pages/install-manual.adoc
@@ -70,7 +70,7 @@ To begin, we will run a configuration tool. This aids in generating the environm
 | `RTF_ENDPOINT` | The Anypoint control plane you're registering to, available on the Create Runtime Fabric page. | `anypoint.mulesoft.com`
 | `RTF_INSTALL_PACKAGE_URL` | The URL of the Runtime Fabric installation package, available on the Create Runtime Fabric page. _If this is not specified, the installer will expect you to manually copy the installation package to_ `/opt/anypoint/runtimefabric/installer.tar.gz`. | `https://s3.amazonaws.com/runtimefabric/...`
 | `RTF_NAME` | The name of your Runtime Fabric cluster. | `runtime-fabric`
-| `RTF_MULE_LICENSE` | A base64 encoded value of the Mule Enterprise license key binary file obtained from MuleSoft. | `==ABCD12934...`
+| `RTF_MULE_LICENSE` | The base64 encoded content of the Mule Enterprise license key binary file obtained from MuleSoft. | `==ABCD12934...`
 | `RTF_TOKEN` | Optional. The token used to join each other VM to the installer VM. This should be a unique value to avoid conflicts during installation. | `my-rtf-token`
 | `RTF_HTTP_PROXY` | Optional. A hostname and port for a HTTP proxy server to forward outbound HTTP requests. | `1.1.1.1:80`
 | `RTF_TCP_PROXY` | Optional. A hostname and port for a TCP proxy server to forward outbound TCP requests. | `1.1.1.2:800`
@@ -175,7 +175,7 @@ tail -f /var/log/rtf-init.log
 [NOTE]
 You can tail the same log on each VM to view its progress.
 
-When the installation completes successfully, the file `/opt/anypoint/runtimefabric/init-succeeded` is created.
+When the installation completes successfully, the file `/opt/anypoint/runtimefabric/.state/init-complete` is created.
 
 === Errors During Installation
 

--- a/modules/ROOT/pages/install-manual.adoc
+++ b/modules/ROOT/pages/install-manual.adoc
@@ -116,24 +116,16 @@ mkdir -p /opt/anypoint/runtimefabric && cp ./rtf-install-scripts/scripts/init.sh
 sudo /opt/anypoint/runtimefabric/init.sh foreground
 ----
 +
-. Once the installer VM has successfully completed the pre-flight checks and is running the installation process, run the same command to execute the `init.sh` script in privileged mode on all the other VMs. This step can be performed across each VM concurrently. The log output should look similar to the following when the pre-flght checks are met.
+. Once the installer VM has successfully completed the pre-flight checks and is running the installation process, run the same command to execute the `init.sh` script in privileged mode on all the other VMs. This step can be performed across each VM concurrently. The log output should continue past the "Execute preflight checks" message to indicate the checks have passed:
 +
 ----
 ...
-Extracting installer package...
-Done
-Tue Aug 14 02:27:43 UTC Starting installer
-Tue Aug 14 02:28:31 UTC Preparing for installation
-Tue Aug 14 02:28:51 UTC Installing application runtime-fabric:1.0.0-59e7ede
-Tue Aug 14 02:28:51 UTC Starting non-interactive install
-Tue Aug 14 02:28:52 UTC Bootstrapping local state
-Tue Aug 14 02:28:52 UTC Still waiting for 1 nodes of role "controller_node"
-Tue Aug 14 02:28:53 UTC All agents have connected!
 Tue Aug 14 02:28:54 UTC Starting the installation
 Tue Aug 14 02:28:56 UTC Operation has been created
-Tue Aug 14 02:28:57 UTC Execute preflight checks <-------------
+Tue Aug 14 02:28:57 UTC Execute preflight checks
 Tue Aug 14 02:29:48 UTC Configure packages for all nodes
 Tue Aug 14 02:29:59 UTC Bootstrap all nodes
+...
 ----
 
 [NOTE]

--- a/modules/ROOT/pages/install-manual.adoc
+++ b/modules/ROOT/pages/install-manual.adoc
@@ -25,7 +25,7 @@ Prepare the necessary steps and understand the core concepts prior to installing
 The installer script ZIP file includes the necessary scripts needed to install Runtime Fabric. Download it to a controller VM you wish to act as the leader during the installation. It'll be referred to as the installer VM.
 
 [NOTE]
-If you're unable to follow these steps, please reach out to your Customer Success Manager for more information on how to get Anypoint Runtime Fabric enabled for your account.
+If you're unable to follow these steps, contact your Customer Success Manager for more information on how to get Anypoint Runtime Fabric enabled for your account.
 
 . Log in to Anypoint platform and navigate to Runtime Manager.
 . On the left navigation pane, select "Runtime Fabrics".

--- a/modules/ROOT/pages/install-manual.adoc
+++ b/modules/ROOT/pages/install-manual.adoc
@@ -110,13 +110,24 @@ mkdir -p /opt/anypoint/runtimefabric && cp ./rtf-install-scripts/scripts/init.sh
 
 == Installation
 
+After the required values are defined and placed on each VM, an initialization script will be run on each VM to run through the installation. The script is the same on each VM; the values defined in the earlier step determine the role and verification checks for each VM during installation.
+
+=== Understanding the Process
+
+The installer VM will download the installer package, unpack it and begin installation. The other VMs will wait for the installer VM to progress with installation until it's able to make the installer files transferrable. Each VM will then transfer the files from the installer VM and carry out their own installation procedure.
+
+When installation has been completed, a cluster will be formed across all VMs. The installer VM will then carry out the registration step using the Anypoint Organization ID, token, and region specified.
+
+After registration has completed, you'll see the name used when provisioning Runtime Fabric in Anypoint Runtime Manager, under the Runtime Fabrics tab. The installation script on the installer VM will proceed to insert the Mule Enterprise license in Runtime Fabric.
+
+=== Steps
 . Run the `init.sh` script in privileged mode on the `installer` VM:
 +
 ----
 sudo /opt/anypoint/runtimefabric/init.sh foreground
 ----
 +
-. Once the installer VM has successfully completed the pre-flight checks and is running the installation process, run the same command to execute the `init.sh` script in privileged mode on all the other VMs. This step can be performed across each VM concurrently. The log output should continue past the "Execute preflight checks" message to indicate the checks have passed:
+. Wait until the installer VM has successfully completed the pre-flight checks. The output should continue past the "Execute preflight checks" message to indicate the checks have passed:
 +
 ----
 ...
@@ -127,15 +138,17 @@ Tue Aug 14 02:29:48 UTC Configure packages for all nodes
 Tue Aug 14 02:29:59 UTC Bootstrap all nodes
 ...
 ----
++
+. Run the same command to execute the `init.sh` script in privileged mode on all the other VMs. This step can be performed across each VM concurrently.
++
+----
+sudo /opt/anypoint/runtimefabric/init.sh foreground
+----
++
+. If the installation process encounters an error, it'll exit with a message to help indicate how to resolve the error. In most cases, errors can be resolved by updating one or more variables to a valid value, and re-running the `init.sh` script.
 
 [NOTE]
 This step will install Runtime Fabric across all VMs to form a cluster. It may take 15-25 minutes or longer to complete.
-
-The installer VM will download the installer package, unpack it and begin installation. The other VMs will wait for the installer VM to progress with installation until it's able to make the installer files transferrable. Each VM will then transfer the files from the installer VM and carry out their own installation procedure.
-
-When installation has been completed, a cluster will be formed across all VMs. The installer VM will then carry out the registration step using the Anypoint Organization ID, token, and region specified.
-
-After registration has completed, you'll see the name used when provisioning Runtime Fabric in Anypoint Runtime Manager, under the Runtime Fabrics tab. The installation script on the installer VM will proceed to insert the Mule Enterprise license digest in Runtime Fabric.
 
 When finished, verify the installation by running this command to view the health of the Runtime Fabric cluster on any VM; you should see each VM in the cluster with a status equal to `healthy`.
 ----
@@ -161,6 +174,11 @@ tail -f /var/log/rtf-init.log
 You can tail the same log on each VM to view its progress.
 
 When the installation completes successfully, the file `/opt/anypoint/runtimefabric/init-succeeded` is created.
+
+=== Errors During Installation
+
+If the installation process encounters an error, it'll exit with a message to help indicate how to resolve the error. In most cases, errors can be resolved by updating one or more variables to a valid value, and re-running the `init.sh` script.
+
 
 == Next Steps
 

--- a/modules/ROOT/pages/install-manual.adoc
+++ b/modules/ROOT/pages/install-manual.adoc
@@ -83,7 +83,7 @@ To begin, we will run a configuration tool. This aids in generating the environm
 To help identify the block device paths to your disks, run the `lsblk` command on the VMs.
 
 . If needed, open a shell/SSH on the installer VM and navigate to the `manual` directory from the unzipped directory.
-. Copy the command below in a text editor to aid in filling in each of the variables.
+. Copy the command below in a text editor to aid in filling in each of the variables inside the single qoutes.
 +
 ----
 RTF_CONTROLLER_IPS='' \

--- a/modules/ROOT/pages/install-manual.adoc
+++ b/modules/ROOT/pages/install-manual.adoc
@@ -146,6 +146,8 @@ sudo /opt/anypoint/runtimefabric/init.sh foreground
 ----
 +
 . If the installation process encounters an error, it'll exit with a message to help indicate how to resolve the error. In most cases, errors can be resolved by updating one or more variables to a valid value, and re-running the `init.sh` script.
++
+. After the installation has completed, a host, username and password will be outputted to access the Ops Center. Copy these credentials and store them securely.
 
 [NOTE]
 This step will install Runtime Fabric across all VMs to form a cluster. It may take 15-25 minutes or longer to complete.

--- a/modules/ROOT/pages/install-manual.adoc
+++ b/modules/ROOT/pages/install-manual.adoc
@@ -116,10 +116,24 @@ mkdir -p /opt/anypoint/runtimefabric && cp ./rtf-install-scripts/scripts/init.sh
 sudo /opt/anypoint/runtimefabric/init.sh foreground
 ----
 +
-. Once the installer VM has successfully completed the pre-flight checks and is running the installation process, run the `init.sh` script in privileged mode on all the other VMs. This step can be performed concurrently.
+. Once the installer VM has successfully completed the pre-flight checks and is running the installation process, run the same command to execute the `init.sh` script in privileged mode on all the other VMs. This step can be performed across each VM concurrently. The log output should look similar to the following when the pre-flght checks are met.
 +
 ----
-sudo /opt/anypoint/runtimefabric/init.sh foreground
+...
+Extracting installer package...
+Done
+Tue Aug 14 02:27:43 UTC Starting installer
+Tue Aug 14 02:28:31 UTC Preparing for installation
+Tue Aug 14 02:28:51 UTC Installing application runtime-fabric:1.0.0-59e7ede
+Tue Aug 14 02:28:51 UTC Starting non-interactive install
+Tue Aug 14 02:28:52 UTC Bootstrapping local state
+Tue Aug 14 02:28:52 UTC Still waiting for 1 nodes of role "controller_node"
+Tue Aug 14 02:28:53 UTC All agents have connected!
+Tue Aug 14 02:28:54 UTC Starting the installation
+Tue Aug 14 02:28:56 UTC Operation has been created
+Tue Aug 14 02:28:57 UTC Execute preflight checks <-------------
+Tue Aug 14 02:29:48 UTC Configure packages for all nodes
+Tue Aug 14 02:29:59 UTC Bootstrap all nodes
 ----
 
 [NOTE]

--- a/modules/ROOT/pages/install-manual.adoc
+++ b/modules/ROOT/pages/install-manual.adoc
@@ -70,7 +70,7 @@ To begin, we will run a configuration tool. This aids in generating the environm
 | `RTF_ENDPOINT` | The Anypoint control plane you're registering to, available on the Create Runtime Fabric page. | `anypoint.mulesoft.com`
 | `RTF_INSTALL_PACKAGE_URL` | The URL of the Runtime Fabric installation package, available on the Create Runtime Fabric page. _If this is not specified, the installer will expect you to manually copy the installation package to_ `/opt/anypoint/runtimefabric/installer.tar.gz`. | `https://s3.amazonaws.com/runtimefabric/...`
 | `RTF_NAME` | The name of your Runtime Fabric cluster. | `runtime-fabric`
-| `RTF_MULE_LICENSE` | The base64 encoded content of the Mule Enterprise license key binary file obtained from MuleSoft. | `==ABCD12934...`
+| `RTF_MULE_LICENSE` | The base64 encoded contents of the Mule Enterprise license key binary file obtained from MuleSoft. | `==ABCD12934...`
 | `RTF_TOKEN` | Optional. The token used to join each other VM to the installer VM. This should be a unique value to avoid conflicts during installation. | `my-rtf-token`
 | `RTF_HTTP_PROXY` | Optional. A hostname and port for a HTTP proxy server to forward outbound HTTP requests. | `1.1.1.1:80`
 | `RTF_TCP_PROXY` | Optional. A hostname and port for a TCP proxy server to forward outbound TCP requests. | `1.1.1.2:800`

--- a/modules/ROOT/pages/install-manual.adoc
+++ b/modules/ROOT/pages/install-manual.adoc
@@ -62,8 +62,8 @@ To begin, we will run a configuration tool. This aids in generating the environm
 |Parameter | Description | Example
 | `RTF_CONTROLLER_IPS` | IP addresses of the controller VMs, separated by whitespace. The first IP address serves as the installer VM. | `"10.3.0.4 10.3.0.5 10.3.0.6"`
 | `RTF_WORKER_IPS` | IP addresses of the worker VMs, separated by whitespace. | `"10.3.0.11 10.3.0.12 10.3.0.13"`
-| `RTF_DOCKER_DEVICE` |  Block device path for the dedicated disk used for Docker, supporting 1000 provisioned IOPS. | `/dev/xvdc`
-| `RTF_ETCD_DEVICE` |  Block device path for the dedicated disk used for etcd, supporting 3000 provisioned IOPS. | `/dev/xvdb`
+| `RTF_DOCKER_DEVICE` |  Block device path for the dedicated disk used for Docker, supporting 1000 provisioned IOPS. The minimum value required for development is 100 GiB; and for production is 250 GiB. | `/dev/xvdc`
+| `RTF_ETCD_DEVICE` |  Block device path for the dedicated disk used for etcd, supporting 3000 provisioned IOPS. The minimum value required is 60 GiB. | `/dev/xvdb`
 | `RTF_AUTH_TOKEN` | An active Anypoint authentication token, available on the Create Runtime Fabric page. | `Bearer 626d7810-0730-498b-bd48-544490c2226b`
 | `RTF_REGION` | The Anypoint broker region you're registering to, available on the Create Runtime Fabric page. | `us-east-1`
 | `RTF_ORG_ID` | The ID for your Anypoint organization, available on the Create Runtime Fabric page. | `2f99d26-a3c2-4023-b303-5528sdd5v022`
@@ -181,6 +181,7 @@ When the installation completes successfully, the file `/opt/anypoint/runtimefab
 
 If the installation process encounters an error, it'll exit with a message to help indicate how to resolve the error. In most cases, errors can be resolved by updating one or more variables to a valid value, and re-running the `init.sh` script.
 
+For help with resolving common errors during installation, see xref:install-common-errors.adoc[Common errors during installation].
 
 == Next Steps
 

--- a/modules/ROOT/pages/install-port-reqs.adoc
+++ b/modules/ROOT/pages/install-port-reqs.adoc
@@ -42,13 +42,28 @@ The following table lists the ports that must be accessible when installing Anyp
 | 4242 | TCP | Internal | Bandwidth checker
 |===
 
+== Port IPs and Hostnames to Whitelist
+
+In your network, you may need to whitelist the hostnames and ports of various parts of the Anypoint Platform to allow Anypoint Runtime Fabric to communicate with the MuleSoft-managed online Anypoint Platform APIs and services.
+
+These tables show you the ports and hostnames to add to your whitelists to allow communication between Runtime Fabric and Anypoint Platform:
+
+[%header%autowidth.spread]
+|===
+| Port | Protocol | Hostnames
+| 5672 | TCP (AMQP) | `transport-layer.prod.cloudhub.io`
+| 443 | HTTPS | `*.prod.cloudhub.io`
+| 443 | HTTPS | `anypoint.mulesoft.com`
+| 443 | HTTPS | `*.anypoint.mulesoft.com`
+.2+| 443 .2+| HTTPS | US control plane: `ecr.us-east-1.amazonaws.com`
+| EU control plane: `ecr.eu-central-1.amazonaws.com`
+
+|===
+
 == Required Network Settings
 
 The following are the network settings required for Anypoint Runtime Fabric:
 
-* Outbound access to download the runtime images from one of the following endpoints:
-** US control plane: `ecr.us-east-1.amazonaws.com` on port 443.
-** EU control plane: `ecr.eu-central-1.amazonaws.com` on port 443.
 * A subnet with enough IP address allotable to add additional VMs to Runtime Fabric.
 * Shell/SSH access to each VM used to install Runtime Fabric.
 

--- a/modules/ROOT/pages/install-port-reqs.adoc
+++ b/modules/ROOT/pages/install-port-reqs.adoc
@@ -57,8 +57,8 @@ These tables show you the ports and hostnames to add to your whitelists to allow
 | 443 | HTTPS | `*.anypoint.mulesoft.com`
 | 443 | HTTPS | `*.googleapis.com`
 | 443 | HTTPS | `worker-cloud-helm-prod.s3.amazonaws.com`
-.2+| 443 .2+| HTTPS | US control plane: `ecr.us-east-1.amazonaws.com`
-| EU control plane: `ecr.eu-central-1.amazonaws.com`
+.2+| 443 .2+| HTTPS | US control plane: `*.ecr.us-east-1.amazonaws.com`
+| EU control plane: `*.ecr.eu-central-1.amazonaws.com`
 
 |===
 

--- a/modules/ROOT/pages/install-port-reqs.adoc
+++ b/modules/ROOT/pages/install-port-reqs.adoc
@@ -55,6 +55,8 @@ These tables show you the ports and hostnames to add to your whitelists to allow
 | 443 | HTTPS | `*.prod.cloudhub.io`
 | 443 | HTTPS | `anypoint.mulesoft.com`
 | 443 | HTTPS | `*.anypoint.mulesoft.com`
+| 443 | HTTPS | `*.googleapis.com`
+| 443 | HTTPS | `worker-cloud-helm-prod.s3.amazonaws.com`
 .2+| 443 .2+| HTTPS | US control plane: `ecr.us-east-1.amazonaws.com`
 | EU control plane: `ecr.eu-central-1.amazonaws.com`
 

--- a/modules/ROOT/pages/installation.adoc
+++ b/modules/ROOT/pages/installation.adoc
@@ -28,8 +28,10 @@ The default behavior of the AWS and Azure provisioning scripts creates a set of 
 
 The disks required to run Anypoint Runtime Fabric are used for the following:
 
-* Each controller VM requires a minimum of 60 GiB dedicated disk with at least 3000 IOPS to run the etcd distributed database.
-* Each controller and worker VM requires a minimum of 250 GiB dedicated disk with at least 1000 IOPS for Docker overlay and other internal services.
+* Each controller VM requires a minimum of 60 GiB dedicated disk with at least 3000 IOPS to run the etcd distributed database. 
+** This disk is referred to as the `etcd` device.
+* Each controller and worker VM requires a minimum of 100 GiB (for development) or 250 GiB (for production) dedicated disk with at least 1000 IOPS for Docker overlay and other internal services. 
+** This disk is referred to as the `docker` device.
 
 [NOTE]
 xref:install-sys-reqs.adoc[Verify System Requirements for Anypoint Runtime Fabric] before beginning the installation.

--- a/modules/ROOT/pages/using-opscenter.adoc
+++ b/modules/ROOT/pages/using-opscenter.adoc
@@ -36,6 +36,19 @@ Verify port 32009 is open and accessible in your Security Group, Network Securit
 
 After logging into Ops Center, you'll see a list of tabs on the left of the page. Navigate to "Monitoring" to view the dashboards available for viewing.
 
+=== View Metrics from an Application
+
+With Ops Center, you can view metrics from a deployed application.
+
+. On Ops Center, click on Kubernetes on the left sidebar.
+. Click on the Pods tab.
+. Select the environment ID where the application was deployed on the right dropdown, near the search input.
+. Find the Pod name which begins with the name of your application.
+. Click on the Pod name and select "Monitoring".
+
+The page should redirect to the Monitoring tab with a filter applied to your application. By default, a set of graphs showing the CPU, Memory, Network, and Filesystem usage will be visible.
+
+
 === Cluster and Pods
 
 The dashboards are divided into two main categories:
@@ -48,6 +61,21 @@ The dashboards are divided into two main categories:
 == Viewing Logs
 
 Ops Center shows a stream of logs outputted by applications and services running on Runtime Fabric. Navigate to "Logging" on the left of the page to view the logging interface.
+
+=== View Logs from an Application
+
+With Ops Center, you can view the logs from a deployed application. This can be useful in cases where log forwarding is not set up.
+
+. On Ops Center, click on Kubernetes on the left sidebar.
+. Click on the Pods tab.
+. Select the environment ID where the application was deployed on the right dropdown, near the search input.
+. Find the Pod name which begins with the name of your application.
+. Click on the Pod name and select "Logs".
+
+The page should redirect to the Logs tab with a filter applied to your application.
+
+[NOTE]
+To view the latest logs, click the "Refresh" button on the upper right portion of the page.
 
 === Filters
 


### PR DESCRIPTION
- Simplified wording
- Updated steps to reflect change to simplify adding Mule Enterprise license key
- Added instructions to get Ops Center credentials
- Provided log example to let user know when preflight checks are completed
- Marked fields as optional
- Added instructions to resume installation after error