### PR TITLE
Removing docker.io dependency

### DIFF
--- a/modules/ROOT/pages/install-port-reqs.adoc
+++ b/modules/ROOT/pages/install-port-reqs.adoc
@@ -72,7 +72,6 @@ These tables show you the ports and hostnames to add to your whitelists to allow
 | 443 | HTTPS | `anypoint.mulesoft.com`
 | 443 | HTTPS | `*.anypoint.mulesoft.com`
 | 443 | HTTPS | `kubernetes-charts.storage.googleapis.com`
-| 443 | HTTPS | `*.docker.io`
 | 443 | HTTPS | `worker-cloud-helm-prod.s3.amazonaws.com`
 | 443 | HTTPS | `docker-images-prod.s3.amazonaws.com`
 .2+| 443 .2+| HTTPS | US control plane: `ecr.us-east-1.amazonaws.com`


### PR DESCRIPTION
Team has updated RTF to remove this external dependency from the required hostnames.