### PR TITLE
Add exchange to whitelist hosts

### DIFF
--- a/modules/ROOT/pages/install-port-reqs.adoc
+++ b/modules/ROOT/pages/install-port-reqs.adoc
@@ -74,7 +74,7 @@ The following table lists the ports and hostnames to add to your whitelists to a
 | 443 | HTTPS | `*.anypoint.mulesoft.com`
 | 443 | HTTPS | `kubernetes-charts.storage.googleapis.com`
 | 443 | HTTPS | `worker-cloud-helm-prod.s3.amazonaws.com`
-| 443 | HTTPS | `docker-images-prod.s3.amazonaws.com`
+| 443 | HTTPS | `exchange2-asset-manager-kprod.s3.amazonaws.com`
 .2+| 443 .2+| HTTPS | US control plane: `ecr.us-east-1.amazonaws.com`
 | EU control plane: `ecr.eu-central-1.amazonaws.com`
 .2+| 443 .2+| HTTPS | US control plane: `*.ecr.us-east-1.amazonaws.com`


### PR DESCRIPTION
Also removes `docker-images-prod` which is no longer required