### PR TITLE
Double quote works both in Linux and Windows

### DIFF
--- a/modules/ROOT/pages/deploy-to-runtime-fabric.adoc
+++ b/modules/ROOT/pages/deploy-to-runtime-fabric.adoc
@@ -72,8 +72,8 @@ For newly deployed applications, the status initially displays as *Starting*. Th
 
 To test inbound traffic for deployed applications, you can send a request using the IP address along with a host header set to the domain. The host header depends on the structure of the application URL.
 
-* An application URL with the format of _{app-name}.domain.com_ uses the following request header format: `Host: {app-name}.domain.com`. Here’s an example cURL command to verify: `curl -Lvk -XGET https://{ip-address}/{path} -H 'Host: {app-name}.domain.com'`
-* An application URL with domain.com/{app-name}_ uses the following request header format: `Host: domain.com`. Here’s an example cURL command to verify: `curl -Lvk -XGET https://{ip-address}/{app-name}/{path} -H 'Host: domain.com'`
+* An application URL with the format of _{app-name}.domain.com_ uses the following request header format: `Host: {app-name}.domain.com`. Here’s an example cURL command to verify: `curl -Lvk -XGET https://{ip-address}/{path} -H "Host: {app-name}.domain.com"`
+* An application URL with domain.com/{app-name}_ uses the following request header format: `Host: domain.com`. Here’s an example cURL command to verify: `curl -Lvk -XGET https://{ip-address}/{app-name}/{path} -H "Host: domain.com"`
 
 == Common Issues
 


### PR DESCRIPTION
C:\Users\Administrator>curl -k https://52.62.6.32/hello -H "Host: rtf-hello.rtf.com"
Hello from RTF

C:\Users\Administrator>curl -k https://52.62.6.32/hello -H 'Host: rtf-hello.rtf.com'
curl: (6) Could not resolve host: rtf-hello.rtf.com'

Single quote doesn't work in Windows. Double quote works both in Linux and Windows