### PR TITLE
Add cpuMax & memoryReserved properties

### DIFF
--- a/modules/ROOT/pages/deploy-maven-3.x.adoc
+++ b/modules/ROOT/pages/deploy-maven-3.x.adoc
@@ -63,7 +63,9 @@ This enables the Mule Maven Plugin in your project.
             </properties>
             <deploymentSettings>
                 <cpuReserved>500m</cpuReserved>
+                <cpuMax>500m</cpuMax>
                 <memoryReserved>800Mi</memoryReserved>
+                <memoryMax>800Mi</memoryMax>
             </deploymentSettings>
         </runtimeFabricDeployment>
     </configuration>
@@ -122,22 +124,26 @@ The default value is `1`
 | lastMileSecurity (optional) | enables Last-Mile security to forward HTTPS connections to be decrypted by this application. +
 This requires an SSL certificate to be included in the Mule application and also requires more CPU resources. The default value is `false`.
 | clusteringEnabled (optional) | enable Mule clustering across each replica of the application. You must have at least two replicas of your application. The default value is `false`.
-| memoryReserved (optional) | defines the amount of memory allocated for each replica of the application. The default value is `700MB`. +
+| memoryReserved (optional) | defines the amount of memory allocated for each replica of the application. The default value is `700MB`. memoryReserved has to be less or equal to memoryMax
+| memoryMax (optional) | defines the maximumm amout of memory allocated for each replica of the application. The default value is `700MB`. memoryMax has to be equal to or greater than memoryReserved. If you not sure, just set it the same as memoryReserved. + 
 
 For example:
 
 <deploymentSettings> +
     <memoryReserved>100Mi</memoryReserved> +
+    <memoryMax>100Mi</memoryMax> + 
 </deploymentSettings> +
 
 This will set 100MB of memory to each replica.
 
-| cpuReserved (optional) | specifies the number of cores to be allocated for each replica of the application. The default value is `0.5 vCores`. +
+| cpuReserved (optional) | specifies the number of cores to be allocated for each replica of the application. The default value is `0.5 vCores`. cpuReserved has to be less or equal to cpuMax
+| cpuMax (Optional) | specifies the maximum number of cores to be allocated for each replica of the application. The default value is `0.5 vCores`. cpuMax has to be equal to or greater than cpuReserved. If you not sure, just set it the same as cpuReserved. +
 
 For example:
 
 <deploymentSettings> +
     <cpuReserved>500m</cpuReserved> +
+    <cpuMax>500m</cpuMax> +
 </deploymentSettings> +
 
 This will set 0.5 vCores for each replica.

--- a/modules/ROOT/pages/deploy-maven-3.x.adoc
+++ b/modules/ROOT/pages/deploy-maven-3.x.adoc
@@ -104,7 +104,7 @@ Ensure that the version is equal to or later than the minimum required Mule runt
 | username | Specifies your Anypoint Platform username.
 | password | Specifies your Anypoint Platform password.
 | applicationName | Specifies the name of your application that is stored in Exchange. +
-This name is part of the domain of your deployed app. Depending on the configuration of your internal load balancer, this name can be used as a subdomain used to access your application.
+Depending on the configuration of your internal load balancer, this name may be used as a subdomain for the application endpoint used to access your application.
 | businessGroup (optional) | Specifies the business group where you want to deploy the application. If not defined, the master organization is used as the default.
 | skip | (boolean value) When set to true, skips the plugin deployment goal. The default value is `false`.
 | target | Specifies the Runtime Fabric target name where the application is deployed.

--- a/modules/ROOT/pages/deploy-maven-3.x.adoc
+++ b/modules/ROOT/pages/deploy-maven-3.x.adoc
@@ -5,7 +5,7 @@ in this topic is specific to deploying an application to Mule runtime, version 3
 
 [NOTE]
 To deploy an application to Runtime Fabric, the application must be published in Exchange. 
-You can use Studio, as describe in  xref:studio::export-to-exchange-task.adoc[Publishing a Project to Exchange]. 
+You can use Studio, as described in xref:studio::export-to-exchange-task.adoc[Publishing a Project to Exchange]. 
 Alternatively, use the Mule Maven Plugin. See 
 xref:exchange::to-publish-assets-maven.adoc[Publish and Deploy Exchange Assets Using Maven] for more information.
 
@@ -14,7 +14,7 @@ xref:exchange::to-publish-assets-maven.adoc[Publish and Deploy Exchange Assets U
 Before using Maven to deploy a Mule application, you should be familiar with Maven, managing pom.xml files, 
 and working with Maven plugins.
 
-Before deploying an application to Runtime Fabric, you should understand the number of resources it requires. 
+Before deploying an application to Runtime Fabric, you should understand the number of resources the application requires. 
 See xref:runtime-fabric::deploy-resource-allocation.adoc[Resource Allocation on Anypoint Runtime Fabric] 
 for more information.
 
@@ -100,15 +100,15 @@ application.
 | uri | Specifies your Anypoint Platform URI. +
 If not set, the default value is `+https://anypoint.mulesoft.com+`.
 | muleVersion | Specifies the Mule runtime version installed in your Runtime Fabric instance. +
-Ensure that this value is equal to or later than the minimum required Mule runtime version of your application.
+Ensure that the version is equal to or later than the minimum required Mule runtime version of your application.
 | username | Specifies your Anypoint Platform username.
 | password | Specifies your Anypoint Platform password.
-| applicationName | Specifies the name of your application stored in Exchange. +
+| applicationName | Specifies the name of your application that is stored in Exchange. +
 This name is part of the domain of your deployed app. Depending on the configuration of your internal load balancer, this name can be used as a subdomain used to access your application.
 | businessGroup (optional) | Specifies the business group where you want to deploy the application. If not defined, the master organization is used as the default.
 | skip | (boolean value) When set to true, skips the plugin deployment goal. The default value is `false`.
 | target | Specifies the Runtime Fabric target name where the application is deployed.
-| provider | Specifies the provider type. for Runtime Fabric, set this value to `MC`.
+| provider | Specifies the provider type. For Runtime Fabric, set this value to `MC`.
 | environment | Specifies the Anypoint Platform environment where you want to deploy your application.
 | properties (optional) | Specifies a top-level element. +
 To set properties for your Mule application, use the <properties> element:

--- a/modules/ROOT/pages/deploy-maven-3.x.adoc
+++ b/modules/ROOT/pages/deploy-maven-3.x.adoc
@@ -1,6 +1,7 @@
 = Deploy an Application to Runtime Fabric using Maven (Mule 3.x)
 
-Runtime Fabric supports using Maven to manage and deploy Mule applications using Maven. The information in this topic is specific to deploying an application to Mule runtime, version 3.x.
+Runtime Fabric supports using Maven to manage and deploy Mule applications using Maven. The information 
+in this topic is specific to deploying an application to Mule runtime, version 3.x.
 
 [NOTE]
 To deploy an application to Runtime Fabric, the application must be published in Exchange. 
@@ -69,9 +70,7 @@ This enables the Mule Maven Plugin in your project.
             </properties>
             <deploymentSettings>
                 <cpuReserved>500m</cpuReserved>
-                <cpuMax>500m</cpuMax>
                 <memoryReserved>800Mi</memoryReserved>
-                <memoryMax>800Mi</memoryMax>
             </deploymentSettings>
         </runtimeFabricDeployment>
     </configuration>
@@ -134,31 +133,23 @@ The default value is `false`.
 | clusteringEnabled (optional) | Enables Mule clustering across each replica of the application. 
 You must have at least two replicas of your application. The default value is `false`.
 | memoryReserved (optional) | Defines the amount of memory allocated for each replica of the application. 
-The default value is `700MB`. The value of `memoryReserved` must be less than or equal to `memoryMax`.
-| memoryMax (optional) | Defines the maximum amount of memory allowed for each replica of the application. 
-The default value is `700MB`. The value of `memoryMax` must be equal to or greater than `memoryReserved`. 
-If you don't know what value to use, set it equal to `memoryReserved`. + 
+The default value is `700MB`. 
 
 For example:
 
 <deploymentSettings> +
-    <memoryReserved>100Mi</memoryReserved> +
-    <memoryMax>100Mi</memoryMax> + 
+    <memoryReserved>100Mi</memoryReserved> + 
 </deploymentSettings> +
 
 This will set 100MB of memory to each replica.
 
 | cpuReserved (optional) | Specifies the number of cores to be allocated for each replica of the application. 
-The default value is `0.5 vCores`. The value of `cpuReserved` must be less than or equal to `cpuMax`.
-| cpuMax (Optional) | Specifies the maximum number of cores allowed for each replica of the application. 
-The default value is `0.5 vCores`. The value of `cpuMax` must be equal to or greater than `cpuReserved`. 
-If you don't know what value to use, set it equal to `cpuReserved`. +
+The default value is `0.5 vCores`. 
 
 The following example specifies 0.5 vCores for each replica:
 
 <deploymentSettings> +
     <cpuReserved>500m</cpuReserved> +
-    <cpuMax>500m</cpuMax> +
 </deploymentSettings> +
 
 | server (optional) | Specifies the Maven server that contains Anypoint Platform credentials. This is property is only required if you want to use the credentials stored in your Maven `settings.xml` file. Note: This is not the Mule server name.

--- a/modules/ROOT/pages/deploy-maven-3.x.adoc
+++ b/modules/ROOT/pages/deploy-maven-3.x.adoc
@@ -14,7 +14,7 @@ xref:exchange::to-publish-assets-maven.adoc[Publish and Deploy Exchange Assets U
 Before using Maven to deploy a Mule application, you should be familiar with Maven, managing pom.xml files, 
 and working with Maven plugins.
 
-Before deploying an application to Runtime Fabric you should understand the number of resources it requires. 
+Before deploying an application to Runtime Fabric, you should understand the number of resources it requires. 
 See xref:runtime-fabric::deploy-resource-allocation.adoc[Resource Allocation on Anypoint Runtime Fabric] 
 for more information.
 
@@ -33,7 +33,7 @@ Add the plugin to your project by adding the following dependency:
 ----
 
 [NOTE]
-It is important to enable extensions for this plugin using `<extensions>true</extensions>`
+It is important to enable extensions for this plugin using `<extensions>true</extensions>`.
 
 In addition to the plugin, you must also add `pluginRepositories` to your Mule application project:
 
@@ -51,7 +51,7 @@ This enables the Mule Maven Plugin in your project.
 == Deploying to Runtime Fabric
 
 . Ensure the Mule Maven Plugin is added to your pom.xml file.
-. In the `<plugin>` element, add a configuration for your Runtime Fabric deployment as shown below:
+. In the `<plugin>` element, add a configuration for your Runtime Fabric deployment as shown in the following example:
 +
 ----
 <plugin>
@@ -113,11 +113,9 @@ This name is part of the domain of your deployed app. Depending on the configura
 | properties (optional) | Specifies a top-level element. +
 To set properties for your Mule application, use the <properties> element:
 
-
 <properties> +
   <key>value</key> +
 </properties>
-
 
 For example:
 
@@ -141,7 +139,7 @@ For example:
     <memoryReserved>100Mi</memoryReserved> + 
 </deploymentSettings> +
 
-This will set 100MB of memory to each replica.
+This sets 100MB of memory to each replica.
 
 | cpuReserved (optional) | Specifies the number of cores to be allocated for each replica of the application. 
 The default value is `0.5 vCores`. 

--- a/modules/ROOT/pages/deploy-maven-3.x.adoc
+++ b/modules/ROOT/pages/deploy-maven-3.x.adoc
@@ -3,18 +3,24 @@
 Runtime Fabric supports using Maven to manage and deploy Mule applications using Maven. The information in this topic is specific to deploying an application to Mule runtime, version 3.x.
 
 [NOTE]
-To deploy an application to Runtime Fabric, the application must be published in Exchange. You can use Studio, as describe in  xref:studio::export-to-exchange-task.adoc[Publishing a Project to Exchange]. Alternatively, use the Mule Maven Plugin. See xref:exchange::to-publish-assets-maven.adoc[Publish and Deploy Exchange Assets Using Maven] for more information.
-
+To deploy an application to Runtime Fabric, the application must be published in Exchange. 
+You can use Studio, as describe in  xref:studio::export-to-exchange-task.adoc[Publishing a Project to Exchange]. 
+Alternatively, use the Mule Maven Plugin. See 
+xref:exchange::to-publish-assets-maven.adoc[Publish and Deploy Exchange Assets Using Maven] for more information.
 
 == Prerequisites
 
-Before using Maven to deploy a Mule application, you should be familiar with Maven, managing pom.xml files, and working with Maven plugins.
+Before using Maven to deploy a Mule application, you should be familiar with Maven, managing pom.xml files, 
+and working with Maven plugins.
 
-Before deploying an application to Runtime Fabric you should understand the number of resource it requires. See xref:runtime-fabric::deploy-resource-allocation.adoc[Resource Allocation on Anypoint Runtime Fabric] for more information.
+Before deploying an application to Runtime Fabric you should understand the number of resource it requires. 
+See xref:runtime-fabric::deploy-resource-allocation.adoc[Resource Allocation on Anypoint Runtime Fabric] 
+for more information.
 
 == Add the Mule Maven Plugin to a Mule Project
 
-To deploy a Mule application using Maven, you must add the Mule Maven Plugin to the application project. Add the plugin to you project by adding the following dependency:
+To deploy a Mule application using Maven, you must add the Mule Maven Plugin to the application project. 
+Add the plugin to you project by adding the following dependency:
 
 ----
 <plugin>
@@ -83,28 +89,29 @@ This example uses placeholder values. Configure each value with values specific 
 
 == Redeploy to Runtime Fabric
 
-To redeploy the application, run the same command as you did to deploy. Runtime Fabric rewrites the application you had deployed.
+To redeploy the application, run the same command as you did to deploy. Runtime Fabric rewrites the 
+application you previously deployed.
 
 == Runtime Fabric Deployment Reference
 
 [%header%autowidth.spread,cols="a,a"]
 |===
 |Parameter | Description
-|runtimeFabricDeployment | specifies a top-level element.
-| uri | specifies your Anypoint Platform URI. +
+|runtimeFabricDeployment | Specifies a top-level element.
+| uri | Specifies your Anypoint Platform URI. +
 If not set, the default value is `+https://anypoint.mulesoft.com+`.
-| muleVersion | specifies the Mule runtime version installed in your Runtime Fabric instance. +
+| muleVersion | Specifies the Mule runtime version installed in your Runtime Fabric instance. +
 Ensure that this value is at equal or higher than the minimum required Mule runtime version of your application.
-| username | specifies your Anypoint Platform username.
-| password | specifies your Anypoint Platform password.
-| applicationName | specifies the name of your application deployed in Exchange. +
+| username | Specifies your Anypoint Platform username.
+| password | Specifies your Anypoint Platform password.
+| applicationName | Specifies the name of your application deployed in Exchange. +
 This name is part of the domain of your deployed app.
-| businessGroup (optional) | specifies the business group where you want to deploy the application. If not defined, name of the master organization is used as the default.
+| businessGroup (optional) | Specifies the business group where you want to deploy the application. If not defined, the name of the master organization is used as the default.
 | skip | (boolean value) When set to true, skips the plugin deployment goal. The default value is `false`.
-| target | specifies the Runtime Fabric target name where the applicateion is deployed.
-| provider | specifies the rovider type. The only supported value for Runtime Fabric is `MC`.
-| environment | specifies the Anypoint Platform environment where you want to deploy your application.
-| properties (optional) | specifies a top-level element. +
+| target | Specifies the Runtime Fabric target name where the applicateion is deployed.
+| provider | Specifies the rovider type. The only supported value for Runtime Fabric is `MC`.
+| environment |Specifies the Anypoint Platform environment where you want to deploy your application.
+| properties (optional) | Specifies a top-level element. +
 To set properties for your Mule application, use the <properties> element:
 
 
@@ -118,14 +125,19 @@ For example:
 <properties> +
   <http.port>8081</http.port> +
 </properties>
-| replicationFactor (optional) | specifies the number of instances created for your application. +
+| replicationFactor (optional) | Specifies the number of instances created for your application. +
 The default value is `1`
-| publicUrl (optional) | specifies the Url of the deployed application.
-| lastMileSecurity (optional) | enables Last-Mile security to forward HTTPS connections to be decrypted by this application. +
-This requires an SSL certificate to be included in the Mule application and also requires more CPU resources. The default value is `false`.
-| clusteringEnabled (optional) | enable Mule clustering across each replica of the application. You must have at least two replicas of your application. The default value is `false`.
-| memoryReserved (optional) | defines the amount of memory allocated for each replica of the application. The default value is `700MB`. memoryReserved has to be less or equal to memoryMax
-| memoryMax (optional) | defines the maximumm amout of memory allocated for each replica of the application. The default value is `700MB`. memoryMax has to be equal to or greater than memoryReserved. If you not sure, just set it the same as memoryReserved. + 
+| publicUrl (optional) | Specifies the URL of the deployed application.
+| lastMileSecurity (optional) | Enables Last-Mile security to forward HTTPS connections to be decrypted by this application. +
+This requires an SSL certificate to be included in the Mule application and also requires more CPU resources. 
+The default value is `false`.
+| clusteringEnabled (optional) | Enables Mule clustering across each replica of the application. 
+You must have at least two replicas of your application. The default value is `false`.
+| memoryReserved (optional) | Defines the amount of memory allocated for each replica of the application. 
+The default value is `700MB`. The value of `memoryReserved` must be less than or equal to `memoryMax`.
+| memoryMax (optional) | Defines the maximum amount of memory allowed for each replica of the application. 
+The default value is `700MB`. The value of `memoryMax` must be equal to or greater than `memoryReserved`. 
+If you don't know what value to use, set it equal to `memoryReserved`. + 
 
 For example:
 
@@ -136,18 +148,20 @@ For example:
 
 This will set 100MB of memory to each replica.
 
-| cpuReserved (optional) | specifies the number of cores to be allocated for each replica of the application. The default value is `0.5 vCores`. cpuReserved has to be less or equal to cpuMax
-| cpuMax (Optional) | specifies the maximum number of cores to be allocated for each replica of the application. The default value is `0.5 vCores`. cpuMax has to be equal to or greater than cpuReserved. If you not sure, just set it the same as cpuReserved. +
+| cpuReserved (optional) | Specifies the number of cores to be allocated for each replica of the application. 
+The default value is `0.5 vCores`. The value of `cpuReserved` must be less than or equal to `cpuMax`.
+| cpuMax (Optional) | Specifies the maximum number of cores allowed for each replica of the application. 
+The default value is `0.5 vCores`. The value of `cpuMax` must be equal to or greater than `cpuReserved`. 
+If you don't know what value to use, set it equal to `cpuReserved`. +
 
-For example:
+The following example specifies 0.5 vCores for each replica:
 
 <deploymentSettings> +
     <cpuReserved>500m</cpuReserved> +
     <cpuMax>500m</cpuMax> +
 </deploymentSettings> +
 
-This will set 0.5 vCores for each replica.
-| server (optional) | specifies the Maven server that contains Anypoint Platform credentials. This is property is only required if you want to use the credentials stored in your Maven `settings.xml` file. Note: This is not the Mule server name.
+| server (optional) | Specifies the Maven server that contains Anypoint Platform credentials. This is property is only required if you want to use the credentials stored in your Maven `settings.xml` file. Note: This is not the Mule server name.
 | skipDeploymentVerification | Note: This feature is only available in plugin version 2.3.2 and later. +
 (boolean value). When set to true, skips the status verification of your deployed app. The default value is `false`.
 |===

--- a/modules/ROOT/pages/deploy-maven-3.x.adoc
+++ b/modules/ROOT/pages/deploy-maven-3.x.adoc
@@ -14,14 +14,14 @@ xref:exchange::to-publish-assets-maven.adoc[Publish and Deploy Exchange Assets U
 Before using Maven to deploy a Mule application, you should be familiar with Maven, managing pom.xml files, 
 and working with Maven plugins.
 
-Before deploying an application to Runtime Fabric you should understand the number of resource it requires. 
+Before deploying an application to Runtime Fabric you should understand the number of resources it requires. 
 See xref:runtime-fabric::deploy-resource-allocation.adoc[Resource Allocation on Anypoint Runtime Fabric] 
 for more information.
 
 == Add the Mule Maven Plugin to a Mule Project
 
 To deploy a Mule application using Maven, you must add the Mule Maven Plugin to the application project. 
-Add the plugin to you project by adding the following dependency:
+Add the plugin to your project by adding the following dependency:
 
 ----
 <plugin>
@@ -88,8 +88,8 @@ This example uses placeholder values. Configure each value with values specific 
 
 == Redeploy to Runtime Fabric
 
-To redeploy the application, run the same command as you did to deploy. Runtime Fabric rewrites the 
-application you previously deployed.
+To redeploy the application, run the same command you ran to deploy it. Runtime Fabric redeploys the 
+application.
 
 == Runtime Fabric Deployment Reference
 
@@ -100,16 +100,16 @@ application you previously deployed.
 | uri | Specifies your Anypoint Platform URI. +
 If not set, the default value is `+https://anypoint.mulesoft.com+`.
 | muleVersion | Specifies the Mule runtime version installed in your Runtime Fabric instance. +
-Ensure that this value is at equal or higher than the minimum required Mule runtime version of your application.
+Ensure that this value is equal to or later than the minimum required Mule runtime version of your application.
 | username | Specifies your Anypoint Platform username.
 | password | Specifies your Anypoint Platform password.
-| applicationName | Specifies the name of your application deployed in Exchange. +
-This name is part of the domain of your deployed app.
-| businessGroup (optional) | Specifies the business group where you want to deploy the application. If not defined, the name of the master organization is used as the default.
+| applicationName | Specifies the name of your application stored in Exchange. +
+This name is part of the domain of your deployed app. Depending on the configuration of your internal load balancer, this name can be used as a subdomain used to access your application.
+| businessGroup (optional) | Specifies the business group where you want to deploy the application. If not defined, the master organization is used as the default.
 | skip | (boolean value) When set to true, skips the plugin deployment goal. The default value is `false`.
-| target | Specifies the Runtime Fabric target name where the applicateion is deployed.
-| provider | Specifies the rovider type. The only supported value for Runtime Fabric is `MC`.
-| environment |Specifies the Anypoint Platform environment where you want to deploy your application.
+| target | Specifies the Runtime Fabric target name where the application is deployed.
+| provider | Specifies the provider type. for Runtime Fabric, set this value to `MC`.
+| environment | Specifies the Anypoint Platform environment where you want to deploy your application.
 | properties (optional) | Specifies a top-level element. +
 To set properties for your Mule application, use the <properties> element:
 
@@ -132,7 +132,7 @@ This requires an SSL certificate to be included in the Mule application and also
 The default value is `false`.
 | clusteringEnabled (optional) | Enables Mule clustering across each replica of the application. 
 You must have at least two replicas of your application. The default value is `false`.
-| memoryReserved (optional) | Defines the amount of memory allocated for each replica of the application. 
+| memoryReserved (optional) | Defines the amount of memory allocated for each replica of your application. 
 The default value is `700MB`. 
 
 For example:
@@ -152,7 +152,7 @@ The following example specifies 0.5 vCores for each replica:
     <cpuReserved>500m</cpuReserved> +
 </deploymentSettings> +
 
-| server (optional) | Specifies the Maven server that contains Anypoint Platform credentials. This is property is only required if you want to use the credentials stored in your Maven `settings.xml` file. Note: This is not the Mule server name.
+| server (optional) | Specifies the Maven server that contains Anypoint Platform credentials. This property is only required if you want to use the credentials stored in your Maven `settings.xml` file. Note: This is not the Mule server name.
 | skipDeploymentVerification | Note: This feature is only available in plugin version 2.3.2 and later. +
 (boolean value). When set to true, skips the status verification of your deployed app. The default value is `false`.
 |===


### PR DESCRIPTION
The old doc doesn't have cpuMax/memoryMax properties. The default value cpuMax/memoryMax is 500m/700Mi. This is ok if customers special smaller values for cpuReserved/memoryReserved but the with greater values than 500m/700Mi, the deployment fails.