### PR TITLE
Add the instructions of setting alert sender

### DIFF
--- a/modules/ROOT/pages/configure-alerting.adoc
+++ b/modules/ROOT/pages/configure-alerting.adoc
@@ -34,7 +34,7 @@ spec:
 [%header,cols="2*a"]
 |===
 |Key | Description
-|`smtp.host` | The endpoint of the SMTP server.
+|`<smtp host>` | The endpoint of the SMTP server.
 |`<smtp port>` | The port used to connect to the SMTP server. (465 by default).
 |`<username>` | The username to use when connecting to the SMTP server.
 |`<password>` | The password to use when connecting to the SMTP server.
@@ -43,11 +43,20 @@ spec:
 |===
 +
 . Run the following on the controller VM.
++
 ----
 $ gravity resource create -f alert-smtp.yaml
 ----
 
-Alerts should now be configured to send through your SMTP server.
+. Use the `rtfctl` utility to set the alert sender email address with your SMTP sending domain. We recommend using a distinguishable email address for each cluster to determine which cluster triggers the alert.
++
+----
+$ rtfctl appliance apply alert-smtp-from "sender@example.com"`
+----
+
+Alerts should now be configured to send through your SMTP server with the designated alert sender email address.
+
+
 
 == Built-in Alerts
 
@@ -68,3 +77,4 @@ The following table lists some of default alerts provided by Anypoint Runtime Fa
 
 * xref:runtime-fabric-logs.adoc[Configure Log Forwarding on Anypoint Runtime Fabric]
 * xref:deploy-to-runtime-fabric.adoc[Deploy a Mule Application to a Runtime Fabric]
+* xref:install-rtfctl.adoc[Install rtfctl Utility]

--- a/modules/ROOT/pages/configure-alerting.adoc
+++ b/modules/ROOT/pages/configure-alerting.adoc
@@ -7,8 +7,7 @@ Runtime Fabric enables you to send alerts through an existing SMTP server. Runti
 
 == Install rtfctl 
 
-The `rtfctl` utility is required to manage alert sender email on Runtime Fabric. Follow the steps to xref:install-rtfctl.adoc[install rtfctl] before moving forward.
-
+The `rtfctl` utility is required to manage alert sender email on Runtime Fabric. Perform the steps in xref:install-rtfctl.adoc[install rtfctl] before completing the following steps.
 
 == Procedure
 
@@ -53,13 +52,13 @@ spec:
 $ sudo gravity resource create -f alert-smtp.yaml
 ----
 
-. Use the `rtfctl` utility to set the alert sender email address with your SMTP sending domain. We recommend using a distinguishable email address for each cluster to determine which cluster triggers the alert.
+. Use the `rtfctl` utility to set the alert sender email address containing your SMTP domain. Use a distinguishable email address for each cluster to easily identify the cluster triggering the alert.
 +
 ----
 $ sudo ./rtfctl appliance apply alert-smtp-from "sender@example.com"
 ----
 
-Alerts should now be configured to send through your SMTP server with the designated alert sender email address.
+Alerts with the designated alert sender email address are now configured to be sent through your SMTP server.
 
 == Built-in Alerts
 

--- a/modules/ROOT/pages/configure-alerting.adoc
+++ b/modules/ROOT/pages/configure-alerting.adoc
@@ -52,7 +52,7 @@ spec:
 $ sudo gravity resource create -f alert-smtp.yaml
 ----
 
-. Use the `rtfctl` utility to set the alert sender email address containing your SMTP domain. Use a distinguishable email address for each cluster to easily identify the cluster triggering the alert.
+. Use the `rtfctl` utility to set the alert sender email address containing your SMTP domain. Use a distinguishable email address for each cluster to identify the cluster triggering the alert.
 +
 ----
 $ sudo ./rtfctl appliance apply alert-smtp-from "sender@example.com"

--- a/modules/ROOT/pages/configure-alerting.adoc
+++ b/modules/ROOT/pages/configure-alerting.adoc
@@ -56,7 +56,7 @@ $ sudo gravity resource create -f alert-smtp.yaml
 . Use the `rtfctl` utility to set the alert sender email address with your SMTP sending domain. We recommend using a distinguishable email address for each cluster to determine which cluster triggers the alert.
 +
 ----
-$ sudo ./rtfctl appliance apply alert-smtp-from "sender@example.com"`
+$ sudo ./rtfctl appliance apply alert-smtp-from "sender@example.com"
 ----
 
 Alerts should now be configured to send through your SMTP server with the designated alert sender email address.

--- a/modules/ROOT/pages/configure-alerting.adoc
+++ b/modules/ROOT/pages/configure-alerting.adoc
@@ -7,7 +7,7 @@ Runtime Fabric enables you to send alerts through an existing SMTP server. Runti
 
 == Install rtfctl 
 
-The `rtfctl` utility is required to manage alert sender email on Runtime Fabric. Perform the steps in xref:install-rtfctl.adoc[install rtfctl] before completing the following steps.
+The `rtfctl` utility is required to manage alert sender email on Runtime Fabric. Perform the steps in xref:install-rtfctl.adoc[Install rtfctl] before completing the following steps.
 
 == Procedure
 
@@ -79,4 +79,4 @@ The following table lists some of default alerts provided by Anypoint Runtime Fa
 
 * xref:runtime-fabric-logs.adoc[Configure Log Forwarding on Anypoint Runtime Fabric]
 * xref:deploy-to-runtime-fabric.adoc[Deploy a Mule Application to a Runtime Fabric]
-* xref:install-rtfctl.adoc[Install rtfctl Utility]
+* xref:install-rtfctl.adoc[Install rtfctl]

--- a/modules/ROOT/pages/configure-alerting.adoc
+++ b/modules/ROOT/pages/configure-alerting.adoc
@@ -61,8 +61,6 @@ $ sudo ./rtfctl appliance apply alert-smtp-from "sender@example.com"`
 
 Alerts should now be configured to send through your SMTP server with the designated alert sender email address.
 
-
-
 == Built-in Alerts
 
 The following table lists some of default alerts provided by Anypoint Runtime Fabric:

--- a/modules/ROOT/pages/configure-alerting.adoc
+++ b/modules/ROOT/pages/configure-alerting.adoc
@@ -5,6 +5,11 @@ endif::[]
 
 Runtime Fabric enables you to send alerts through an existing SMTP server. Runtime Fabric provides alert functionality to send notifications when system health is compromised.
 
+== Install rtfctl 
+
+The `rtfctl` utility is required to manage alert sender email on Runtime Fabric. Follow the steps to xref:install-rtfctl.adoc[install rtfctl] before moving forward.
+
+
 == Procedure
 
 . Using a terminal, open a shell/SSH connection to a controller VM.
@@ -45,13 +50,13 @@ spec:
 . Run the following on the controller VM.
 +
 ----
-$ gravity resource create -f alert-smtp.yaml
+$ sudo gravity resource create -f alert-smtp.yaml
 ----
 
 . Use the `rtfctl` utility to set the alert sender email address with your SMTP sending domain. We recommend using a distinguishable email address for each cluster to determine which cluster triggers the alert.
 +
 ----
-$ rtfctl appliance apply alert-smtp-from "sender@example.com"`
+$ sudo ./rtfctl appliance apply alert-smtp-from "sender@example.com"`
 ----
 
 Alerts should now be configured to send through your SMTP server with the designated alert sender email address.

--- a/modules/ROOT/pages/install-rtfctl.adoc
+++ b/modules/ROOT/pages/install-rtfctl.adoc
@@ -11,7 +11,7 @@ Install the `rtfctl` utility to locally manage Runtime Fabrics. The `rtfctl` uti
 * Manage proxy settings.
 * Manage secure properties.
 * Manage a Mule license.
-* Managet the alert sender email address.
+* Manage the alert sender email address.
 
 == Install rtfctl 
 

--- a/modules/ROOT/pages/install-rtfctl.adoc
+++ b/modules/ROOT/pages/install-rtfctl.adoc
@@ -11,6 +11,7 @@ Install the `rtfctl` utility to locally manage Runtime Fabrics. The `rtfctl` uti
 * Manage proxy settings.
 * Manage secure properties.
 * Manage a Mule license.
+* Managet the alert sender email address.
 
 == Install rtfctl 
 

--- a/modules/ROOT/pages/manage-proxy.adoc
+++ b/modules/ROOT/pages/manage-proxy.adoc
@@ -53,7 +53,11 @@ The password must be URL encoded.
 * *<8080>*: Specifies the port on the host where the HTTP proxy is listening for requests.
 * *<1.1.1.1:8888,2.2.2.2:9999>*: Specifies the `NO_PROXY` hosts and ports, delimited by commas.
 * (Optional) `--confirm`: Skips manual acknowledgement of the change. If not specified, the `rtfctl apply proxy` command prompts you to confirm the change before continuing.
-. To verify the change was successful, run the following command to output the current value of the HTTP proxy: `sudo ./rtfctl get http-proxy`.
+. To verify the change was successful, run the following command to output the current value of the HTTP proxy:
++
+----
+sudo ./rtfctl get http-proxy
+----
 
 The output should match the value expected.
 

--- a/modules/ROOT/pages/manage-proxy.adoc
+++ b/modules/ROOT/pages/manage-proxy.adoc
@@ -7,7 +7,7 @@ You can update the proxy settings used by Anypoint Runtime Fabric outbound conne
 
 == Install rtfctl 
 
-The `rtfctl` utility is required to manage proxy settings on Runtime Fabric. Follow the steps to xref:install-rtfctl.adoc[install rtfctl] before configuring proxy settings.
+The `rtfctl` utility is required to manage proxy settings on Runtime Fabric. Follow the steps to xref:install-rtfctl.adoc[Install rtfctl] before configuring proxy settings.
 
 == Update the Monitoring Proxy
 

--- a/modules/ROOT/pages/manage-proxy.adoc
+++ b/modules/ROOT/pages/manage-proxy.adoc
@@ -7,7 +7,7 @@ You can update the proxy settings used by Anypoint Runtime Fabric outbound conne
 
 == Install rtfctl 
 
-The `rtfctl` utility is required to manage proxy settings on Runtime Fabric. Follow the steps to xref:install-rtfctl.adoc[install rtfctl] before moving forward with configuring proxy settings.
+The `rtfctl` utility is required to manage proxy settings on Runtime Fabric. Follow the steps to xref:install-rtfctl.adoc[install rtfctl] before continuing with configuring proxy settings.
 
 == Update the Monitoring Proxy
 

--- a/modules/ROOT/pages/manage-proxy.adoc
+++ b/modules/ROOT/pages/manage-proxy.adoc
@@ -7,7 +7,7 @@ You can update the proxy settings used by Anypoint Runtime Fabric outbound conne
 
 == Install rtfctl 
 
-The rtftl tool is required to manage proxy settings on Runtime Fabric. Follow the steps to xref:install-rtfctl.adoc[install rtfctl] before moving forward with configuring proxy settings.
+The `rtfctl` utility is required to manage proxy settings on Runtime Fabric. Follow the steps to xref:install-rtfctl.adoc[install rtfctl] before moving forward with configuring proxy settings.
 
 == Update the Monitoring Proxy
 
@@ -15,7 +15,7 @@ The rtftl tool is required to manage proxy settings on Runtime Fabric. Follow th
 . Run the following command, replacing the placeholder values with the following:
 +
 ----
-rtfctl apply monitoring-proxy "socks5://<user>:<pass>@<10.0.0.2>:<8080>"
+sudo ./rtfctl apply monitoring-proxy "socks5://<user>:<pass>@<10.0.0.2>:<8080>"
 ----
 +
 * *<user>*: the username needed to authenticate to the SOCKS5 proxy.
@@ -25,7 +25,7 @@ The password must be URL encoded.
 * *<10.0.0.2>*: the IP address or hostname used to access the SOCKS5 proxy.
 * *<8080>*: the port on the host where the SOCKS5 proxy is listening for requests.
 . To verify the change was successful, run the following command to output the current value of the monitoring proxy: +
-`rtfctl get monitoring-proxy`
+`sudo ./rtfctl get monitoring-proxy`
 
 The output should match the value expected.
 
@@ -42,7 +42,7 @@ Updating the HTTP proxy causes each machine in the cluster to restart all pods r
 . Run the following command, replacing the placeholder values with the following:
 +
 ----
-rtfctl apply http-proxy "http://<user>:<pass>@<10.0.0.1>:<8080>" --no-proxy "<1.1.1.1:8888,2.2.2.2:9999>"
+sudo ./rtfctl apply http-proxy "http://<user>:<pass>@<10.0.0.1>:<8080>" --no-proxy "<1.1.1.1:8888,2.2.2.2:9999>"
 ----
 +
 * *<user>*: the username needed to authenticate to the HTTP proxy.
@@ -52,13 +52,13 @@ The password must be URL encoded.
 * *<10.0.0.1>*: the IP address or hostname to access the HTTP proxy.
 * *<8080>*: the port on the host where the HTTP proxy is listening for requests.
 * *<1.1.1.1:8888,2.2.2.2:9999>*: the `NO_PROXY` hosts and ports, delimited by commas.
-. To verify the change was successful, run the following command to output the current value of the HTTP proxy: `rtfctl get http-proxy`.
+. To verify the change was successful, run the following command to output the current value of the HTTP proxy: `sudo ./rtfctl get http-proxy`.
 
 The output should match the value expected.
 
 === Run the Script on Each Node
 
-Perform the following steps _only_ if you are using Runtime Fabric installer 1.0.x. Run `rtfctl version` to verify results, reported as the *Server version*.
+Perform the following steps _only_ if you are using Runtime Fabric installer 1.0.x. Run `sudo ./rtfctl version` to verify results, reported as the *Server version*.
 
 . From the controller node used to install Runtime Fabric, copy `set_dockerd_proxy.sh`, which is located under `/opt/anypoint/runtimefabric/scripts/`, to each controller and worker node in the same location (`/opt/anypoint/runtimefabric/scripts/`). +
 [NOTE]

--- a/modules/ROOT/pages/manage-proxy.adoc
+++ b/modules/ROOT/pages/manage-proxy.adoc
@@ -7,7 +7,7 @@ You can update the proxy settings used by Anypoint Runtime Fabric outbound conne
 
 == Install rtfctl 
 
-The `rtfctl` utility is required to manage proxy settings on Runtime Fabric. Follow the steps to xref:install-rtfctl.adoc[install rtfctl] before continuing with configuring proxy settings.
+The `rtfctl` utility is required to manage proxy settings on Runtime Fabric. Follow the steps to xref:install-rtfctl.adoc[install rtfctl] before configuring proxy settings.
 
 == Update the Monitoring Proxy
 

--- a/modules/ROOT/pages/manage-secure-properties.adoc
+++ b/modules/ROOT/pages/manage-secure-properties.adoc
@@ -7,7 +7,7 @@ Secure properties are added in the Runtime Fabric cluster locally, are stored se
 
 == Install rtfctl 
 
-The `rtfctl` utility is required to manage secure properties on Runtime Fabric locally. Follow the steps to xref:install-rtfctl.adoc[install rtfctl] before moving forward with managing secure properties.
+The `rtfctl` utility is required to manage secure properties on Runtime Fabric locally. Follow the steps to xref:install-rtfctl.adoc[install rtfctl] before continuing with managing secure properties.
 
 == Set secure properties
 

--- a/modules/ROOT/pages/manage-secure-properties.adoc
+++ b/modules/ROOT/pages/manage-secure-properties.adoc
@@ -7,7 +7,7 @@ Secure properties are added in the Runtime Fabric cluster locally, are stored se
 
 == Install rtfctl 
 
-The rtfctl tool is required to manage secure properties on Runtime Fabric locally. Follow the steps to xref:install-rtfctl.adoc[install rtfctl] before moving forward with managing secure properties.
+The `rtfctl` utility is required to manage secure properties on Runtime Fabric locally. Follow the steps to xref:install-rtfctl.adoc[install rtfctl] before moving forward with managing secure properties.
 
 == Set secure properties
 
@@ -15,7 +15,7 @@ The rtfctl tool is required to manage secure properties on Runtime Fabric locall
 . Run the following command to set a secure property to the Runtime Fabric under a specific environment, substituting the placeholder fields:
 +
 ----
-rtfctl apply secure-property --key <my_key> --value <my_value> -n <environment_id>
+sudo ./rtfctl apply secure-property --key <my_key> --value <my_value> -n <environment_id>
 ----
 +
 * *<my_key>*: the key for the secure property used in the Mule application to reference the value.
@@ -28,7 +28,7 @@ rtfctl apply secure-property --key <my_key> --value <my_value> -n <environment_i
 . Run the following command to view the secure properties applied to the Runtime Fabric under a specific environment, substituting the placeholder fields:
 +
 ----
-rtfctl get secure-properties -n <environment_id>
+sudo ./rtfctl get secure-properties -n <environment_id>
 ----
 +
 * *<environment_id>*: the Anypoint environment ID to list the secure properties under.

--- a/modules/ROOT/pages/replace-license-key.adoc
+++ b/modules/ROOT/pages/replace-license-key.adoc
@@ -11,7 +11,7 @@ this node is named `rtf-controller-1` by default.
 
 == Install rtfctl 
 
-The `rtfctl` utility is required to replace your Mule license key on Runtime Fabric. Follow the steps to xref:install-rtfctl.adoc[Install rtfctl] before continuing.
+The `rtfctl` utility is required to replace your Mule license key on Runtime Fabric. Follow the steps in xref:install-rtfctl.adoc[Install rtfctl] before continuing.
 
 == Procedure
 
@@ -54,4 +54,4 @@ sudo ./rtfctl get mule-license
 
 == See Also
 
-* xref:runtime-fabric::install-rtfctl.adoc[Install rtfctl Utility]
+* xref:runtime-fabric::install-rtfctl.adoc[Install rtfctl]

--- a/modules/ROOT/pages/replace-license-key.adoc
+++ b/modules/ROOT/pages/replace-license-key.adoc
@@ -11,7 +11,7 @@ this node is named `rtf-controller-1` by default.
 
 == Install rtfctl 
 
-The `rtfctl` utility is required to replace your Mule license key on Runtime Fabric. Follow the steps to xref:install-rtfctl.adoc[install rtfctl] before moving forward.
+The `rtfctl` utility is required to replace your Mule license key on Runtime Fabric. Follow the steps to xref:install-rtfctl.adoc[install rtfctl] before continuing.
 
 == Procedure
 

--- a/modules/ROOT/pages/replace-license-key.adoc
+++ b/modules/ROOT/pages/replace-license-key.adoc
@@ -9,6 +9,12 @@ entered an incorrect license key during installation.
 Perform the following steps on the controller node used to start the installation. For Azure and AWS installations, 
 this node is named `rtf-controller-1` by default.
 
+== Install rtfctl 
+
+The `rtfctl` utility is required to replace your Mule license key on Runtime Fabric. Follow the steps to xref:install-rtfctl.adoc[install rtfctl] before moving forward.
+
+== Procedure
+
 . Base64 encode the new Mule `.lic` license file provided by MuleSoft: 
 
 ** On MacOS, run the following command in the terminal: 
@@ -36,13 +42,13 @@ Base64 value of your license key. For more information on the `rtfctl` command, 
 xref:runtime-fabric::install-rtfctl#supported-commands[rtfctl Supported commands].
 +
 ----
-rtfctl apply mule-license BASE64_ENCODED_LICENSE
+sudo ./rtfctl apply mule-license BASE64_ENCODED_LICENSE
 ----
 +
 . To verify the Mule license key has applied correctly, retrieve the contents using the `rtfctl` utility:
 +
 ----
-rtfctl get mule-license
+sudo ./rtfctl get mule-license
 ----
 
 

--- a/modules/ROOT/pages/replace-license-key.adoc
+++ b/modules/ROOT/pages/replace-license-key.adoc
@@ -11,7 +11,7 @@ this node is named `rtf-controller-1` by default.
 
 == Install rtfctl 
 
-The `rtfctl` utility is required to replace your Mule license key on Runtime Fabric. Follow the steps to xref:install-rtfctl.adoc[install rtfctl] before continuing.
+The `rtfctl` utility is required to replace your Mule license key on Runtime Fabric. Follow the steps to xref:install-rtfctl.adoc[Install rtfctl] before continuing.
 
 == Procedure
 
@@ -39,7 +39,7 @@ base64 -w0 license.lic
 
 . On the controller node acting as the leader during installation (the installer node), use the `rtfctl` utility with the
 Base64 value of your license key. For more information on the `rtfctl` command, refer to 
-xref:runtime-fabric::install-rtfctl#supported-commands[rtfctl Supported commands].
+xref:runtime-fabric::install-rtfctl#list-supported-commands[rtfctl commands].
 +
 ----
 sudo ./rtfctl apply mule-license BASE64_ENCODED_LICENSE

--- a/modules/ROOT/pages/troubleshoot-guide.adoc
+++ b/modules/ROOT/pages/troubleshoot-guide.adoc
@@ -23,12 +23,12 @@ You can use `rtfctl` to verify that Runtime Fabric has the required outbound con
 On each node, follow the instructions in xref:install-rtfctl.adoc[Install rtfctl] to install `rtfctl`. 
 Run the following command in all controller and worker nodes on the cluster to verify the required outbound connectivity:
 ```
-rtfctl test outbound-network
+sudo ./rtfctl test outbound-network
 ```
 
 Sample output:
 ```
-[root@rtf-controller-1 runtimefabric]# ./rtfctl test outbound-network
+[root@rtf-controller-1 runtimefabric]# sudo ./rtfctl test outbound-network
 Using proxy configuration from Runtime Fabric (proxy "", no proxy "")
 
 Using 'US' region

--- a/modules/ROOT/pages/upgrade-cluster.adoc
+++ b/modules/ROOT/pages/upgrade-cluster.adoc
@@ -58,7 +58,7 @@ Keep your browser session open to use in later steps.
 . Verify Runtime Fabric is healthy:
 .. Using your web browser, navigate to the *Runtime Fabrics* tab in Anypoint Runtime Manager and verify that the Runtime Fabric reports an Active status.
 .. Open a terminal to a Runtime Fabric controller node.
-.. Run `gravity status` and confirm the cluster status is healthy.
+.. Run `sudo gravity status` and confirm the cluster status is healthy.
 .. Keep your terminal open to use in later steps.
 . Download the latest version of the `rtfctl` command-line utility:
 .. Using your terminal open on a controller node, run the following command: 
@@ -90,16 +90,16 @@ This command also supports referencing an installer package already downloaded o
 +
 The command outputs a confirmation indicating the upgrade is being performed in the background.
 +
-. Run `gravity status` on a node and verify that the cluster status is “updating”.
+. Run `sudo gravity status` on a node and verify that the cluster status is “updating”.
 . Follow the progress on the upgrade procedure:
 .. Using your terminal open on a controller node, run the following command: 
 +
 ----
-sudo ./gravity plan
+sudo gravity plan
 ----
 +
 . Confirm the upgrade has completed successfully:
-.. Run `sudo ./gravity status` and verify that the cluster status transitioned from “updating” to “active”.
+.. Run `sudo gravity status` and verify that the cluster status transitioned from “updating” to “active”.
 . If the Runtime Fabric cluster version was 1.0.x prior to upgrading, and an HTTP proxy is in use, run this command to apply the HTTP proxy settings: 
 +
 ----
@@ -145,7 +145,7 @@ cd /opt/anypoint/runtimefabric/installer
 . Run the command to resume the upgrade: 
 +
 ----
-sudo ./gravity upgrade --resume
+sudo gravity upgrade --resume
 ----
 +
 . The upgrade continues streaming output to your terminal session. 
@@ -163,20 +163,20 @@ Perform the following steps to resolve common errors:
 . Use the `gravity plan` command to identify the phase in which the upgrade paused: 
 +
 ----
-sudo ./gravity plan
+sudo gravity plan
 ----
 +
 . Resume the upgrade using the debug flag on the phase in which the error occurred: 
 +
 ----
-sudo ./gravity upgrade --phase=< insert phase > --force --debug
+sudo gravity upgrade --phase=< insert phase > --force --debug
 ----
 +
 For example,  `--phase=/gc/rtf-controller-1`.
 . Wait for the command to run again. If the command does not terminate with an error, resume the upgrade by running the following command:
 +
 ----
-sudo ./gravity upgrade --resume
+sudo gravity upgrade --resume
 ----
 . If the command again terminates with an error:
 .. Read the logs to identify which node requires repair.
@@ -191,7 +191,7 @@ sudo gravity plan --repair
 . On the controller node running the upgrade, run the failed phase manually:
 +
 ----
-sudo ./gravity plan execute --phase=< insert phase > --force --debug
+sudo gravity plan execute --phase=< insert phase > --force --debug
 ----
 
 If an error is returned, wait a few minutes and repeat the previous steps.

--- a/modules/ROOT/pages/upgrade-cluster.adoc
+++ b/modules/ROOT/pages/upgrade-cluster.adoc
@@ -145,7 +145,7 @@ cd /opt/anypoint/runtimefabric/installer
 . Run the command to resume the upgrade: 
 +
 ----
-sudo gravity upgrade --resume
+sudo ./gravity upgrade --resume
 ----
 +
 . The upgrade continues streaming output to your terminal session. 
@@ -163,20 +163,20 @@ Perform the following steps to resolve common errors:
 . Use the `gravity plan` command to identify the phase in which the upgrade paused: 
 +
 ----
-sudo gravity plan
+sudo ./gravity plan
 ----
 +
 . Resume the upgrade using the debug flag on the phase in which the error occurred: 
 +
 ----
-sudo gravity upgrade --phase=< insert phase > --force --debug
+sudo ./gravity upgrade --phase=< insert phase > --force --debug
 ----
 +
 For example,  `--phase=/gc/rtf-controller-1`.
 . Wait for the command to run again. If the command does not terminate with an error, resume the upgrade by running the following command:
 +
 ----
-sudo gravity upgrade --resume
+sudo ./gravity upgrade --resume
 ----
 . If the command again terminates with an error:
 .. Read the logs to identify which node requires repair.
@@ -191,7 +191,7 @@ sudo gravity plan --repair
 . On the controller node running the upgrade, run the failed phase manually:
 +
 ----
-sudo gravity plan execute --phase=< insert phase > --force --debug
+sudo ./gravity plan execute --phase=< insert phase > --force --debug
 ----
 
 If an error is returned, wait a few minutes and repeat the previous steps.


### PR DESCRIPTION
* Add the instructions of setting alert sender email. (Related rtfctl PR: https://github.com/mulesoft/rtfctl/pull/61)
* Remove extra `./` for gravity commands.
* Add `sudo` for rtfctl and gravity commands.
* Fix rtfctl typos.
* Quote `rtfctl` and replace "rtfctl tool" with "rtfctl utility" for consistency across pages.