### PR TITLE
Update configure-alerting.adoc

### DIFF
--- a/modules/ROOT/pages/configure-alerting.adoc
+++ b/modules/ROOT/pages/configure-alerting.adoc
@@ -49,6 +49,9 @@ $ gravity resource create -f alert-smtp.yaml
 
 Alerts should now be configured to send through your SMTP server.
 
+[NOTE]
+Currently only a single alerts email recipient is supported.
+
 == Built-in Alerts
 
 The following table lists some of default alerts provided by Anypoint Runtime Fabric:


### PR DESCRIPTION
Adding note: Currently only a single alerts email recipient is supported.
This is already documented here: https://gravitational.com/gravity/docs/monitoring/ so should be called out in our documentation too. This has already generated support cases.