### PR TITLE
Update Docs to match default OpsCenter config

### DIFF
--- a/modules/ROOT/pages/install-azure.adoc
+++ b/modules/ROOT/pages/install-azure.adoc
@@ -189,10 +189,10 @@ infrastructure. See xref:using-opscenter.adoc[Using Ops Center on Anypoint Runti
 accessing Ops Center and determining the Ops Center username and password.
 
 [NOTE]
-By default, the Resource Manager script configures the Azure Network Security Group to not expose the Ops Center port 
-to the internet. To use a public IP to manage your cluster using the Ops Center, the controller nodes must be 
-provisioned with a public IP. Update your 
-Network Security Group to allow 0.0.0.0 internet access for TCP connections on port 32009.
+By default, the Resource Manager script configures the Azure Network Security Group to expose the Ops Center port 
+to the internet. To use a public IP to manage your cluster using the Ops Center, the controller nodes are 
+provisioned with a public IP. The configured 
+Network Security Group allows internet access for TCP connections on port 32009.
 
 == Post Installation Configuration
 


### PR DESCRIPTION
From the template (also I've tested the access after provisioning a dev cluster in an Azure account) we can see that resource public_ip_rtf_X_name is assigned to each controller'nic resource and also this rule is provided for the NSG  :

{
                        "name": "OpsCenter",
                        ...
                        "properties": {
                            "provisioningState": "Succeeded",
                            "description": "Ops Center UI",
                            "protocol": "Tcp",
                            "sourcePortRange": "*",
                            "destinationPortRange": "32009",
                            "sourceAddressPrefix": "Internet",
                            "destinationAddressPrefix": "VirtualNetwork",
                            "access": "Allow",
                            "priority": 1900,
                            "direction": "Inbound",
                            "sourcePortRanges": [],
                            "destinationPortRanges": [],
                            "sourceAddressPrefixes": [],
                            "destinationAddressPrefixes": []
                        }
                    }