### PR TITLE
DOCS-10089 Update manage-backup-restore.adoc

### DIFF
--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -11,7 +11,7 @@ Configuration changes to deployed applications and management services made afte
 
 [NOTE]
 ====
-For Runtime Fabric running on VMs / Bare Metal, the backup process also includes backing up of underneath Kubernetes appliance related custom resources [logforwarder and smtp].  
+For Runtime Fabric on VMs / Bare Metal, the backup and restore process also includes backing up and restoring of underneath Kubernetes appliance related custom resources [logforwarder and smtp].  
 ====
 
 

--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -2,15 +2,15 @@
 
 To preserve applications in the event of system failure, confirm that Runtime Fabric is automatically backed up. When scheduling backups, follow best practices by configuring hourly backups. Store your backup archive on external storage outside the Runtime Fabric cluster.
 
-The state of Runtime Fabric is distributed across the Kubernetes cluster. Use the following procedures to back up and restore the required state necessary for all deployed applications, management services, and their configurations. Individual Kubernetes node VM snapshot backup/restore is currently not supported. 
+The state of Runtime Fabric is distributed across the Kubernetes cluster. Use the following procedures to back up and restore the required state necessary for all deployed applications, management services, and their configurations. Performing a backup per node (such as via a VM snapshot) is not supported.
 
 [WARNING]
 ====
-Configuration changes to deployed applications and management services made after a back up cannot not be restored.  
+Configuration changes to deployed applications and management services made after a back up will not be restored.
 ====
 
 
-For Runtime Fabric on VMs / Bare Metal, the backup and restore process also includes backing up and restoring of underneath Kubernetes appliance related custom resources [logforwarder and smtp].
+For Runtime Fabric on VMs / Bare Metal, the backup and restore process also includes backing up and restoring appliance-related custom resources such as logforwarder and smtp.
 
 
 == Prerequisites for Backing Up Runtime Fabric
@@ -31,7 +31,7 @@ To create a backup run the following command:
 
 This command creates an archive of the current system state in `<path_to_backup_file>`, which can be any path in the file system that you have write access to, for instance `/opt/anypoint/runtimefabric/backup.tar.gz`. 
 
-* For Runtime Fabric on VMs / Bare Metal, the `rtfctl` binary is present in directory `/opt/anypoint/runtimefabric/`. Confirm that you run the backup command on any controller node in the cluster as a privileged user. To use the archive for restoring later, copy the archive file to secure storage that is on a different machine and is not part of the Runtime Fabric cluster. The following command, for example, uses `scp` to copy the archive to another drive: 
+* For Runtime Fabric on VMs / Bare Metal, the `rtfctl` binary is present in directory `/opt/anypoint/runtimefabric/`. Confirm that you run the backup command on a controller node in the cluster as a privileged user. To use the archive for restoring later, copy the archive file to secure storage on a different machine that is not part of Runtime Fabric. The following command, for example, uses `scp` to copy the archive to another drive: 
 +
 ----
 scp your_username@remotehost:/opt/anypoint/runtimefabric/backup.tar.gz /backup-path/to-restore.tar.gz
@@ -46,28 +46,26 @@ Runtime Fabric provides two target options when restoring a cluster from a backu
 * Use an existing Runtime Fabric cluster.
 * Create a new Kubernetes cluster with the same configuration as the backed up cluster. This includes the same number of servers, disks, etc.
 
-To create a new Kubernetes cluster on VMs / Bare Metal without Runtime Fabric being installed, run the Runtime Fabric installer script(s) but do not provide the fabric activation data.
+To create a new Kubernetes cluster on VMs / Bare Metal without Runtime Fabric being installed, run the Runtime Fabric installer script(s) without providing the fabric activation data.
 
 [WARNING]
 ====
-For restoring on existing Runtime Fabric cluster, you must restore on to the same version of Runtime Fabric that you used to create the backup archive. You cannot restore from an older version to a newer version of Runtime Fabric running on the cluster.
+When restoring on an existing Runtime Fabric cluster, the appliance version must be the same as the Runtime Fabric used to create the backup archive. You cannot restore from an older version to a newer version of Runtime Fabric running on the cluster.
 ====
 
-. Copy backup archive file and make sure that it is available to `rtfctl`.
+. Copy the backup archive file and make sure it is available to `rtfctl`.
 +
-* For Runtime Fabric on VMs / Bare Metal, copy the compressed backup archive file to a folder in any of the controller nodes of the environment to be restored. For example, you can transfer this file securely via the following command: 
+* For Runtime Fabric on VMs / Bare Metal, copy the compressed backup archive file to a directory in a controller node of the environment to be restored. For example, you can transfer this file securely via the following command: 
 +
 ----
 scp /backup-path/to-restore.tar.gz your_username@remotehost:/opt/anypoint/runtimefabric/
 ----
 
-. If you are restoring to a newly created cluster, you must first scale down all Runtime Fabric components on the original, backed-up cluster by running the following command:
+. If you are restoring on a newly created cluster, you must first scale down all Runtime Fabric components on the original, backed-up cluster. First, confirm your Kubernetes (kubectl) context is set to the backed up cluster. Then, run the following command:
 +
 ----
 kubectl scale --replicas=0 -n rtf deployment.apps/agent
 ----
-+
-Confirm that your Kubernetes(kubectl) context is set to the backed up cluster before executing the above command.
 
 . Restore the cluster.
 +
@@ -77,7 +75,7 @@ To restore the cluster from the backup archive, run the following command:
 ./rtfctl restore <path_to_backup_file>
 ----
 +
-For Runtime Fabric on Self-Managed Kubernetes, confirm that the `rtfctl` binary is present in the current directory and the Kubernetes (kubectl) context is set to the cluster you are restoring to.
+For Runtime Fabric on Self-Managed Kubernetes, confirm the `rtfctl` binary is present in the current directory and the Kubernetes (kubectl) context is set to the cluster you are restoring to.
 +
 This process may require several minutes to complete.
 

--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -57,19 +57,22 @@ scp /backup-path/to-restore.tar.gz your_username@remotehost:/opt/anypoint/runtim
 +
 For Runtime Fabric on Self-Managed Kubernetes, confirm that the `rtfctl` binary is present in the current directory and the Kubernetes (kubectl) context is set to the cluster you are restoring to.
 
-. Restore the cluster from the backup archive with following command:
+. Restore the cluster from the backup archive.
 +
-----
-rtfctl restore <path_to_backup_file>
-----
-
 Only for restoring on to newly created cluster, on the original backed up cluster, we need scale down all Runtime Fabric components by running the following command:
++
 ----
 kubectl scale --replicas=0 -n rtf deployment.apps/agent
 ----
 Please confirm that your Kubernetes(kubectl) context is set to the backed up cluster before executing the above command.
-
-Runtime Fabric restoring process may require several minutes to complete.
++
+To restore the cluster from the backup archive with following command: 
++
+----
+rtfctl restore <path_to_backup_file>
+----
++
+This process may require several minutes to complete.
 
 == See Also
 

--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -46,7 +46,7 @@ For Runtime Fabric running on Self-Managed Kubernetes, confirm that the `rtfctl`
 
 == Restore a Cluster
 
-To restore cluster on Runtime Fabric from a backup, use an existing Runtime Fabric cluster or create a new Kubernetes cluster with the same configuration (number of servers, disks, and so on) as the backed up cluster.  
+To restore Runtime Fabric cluster from a backup, use an existing Runtime Fabric cluster or create a new Kubernetes cluster with the same configuration (number of servers, disks, and so on) as the backed up cluster.  
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -20,7 +20,7 @@ For Runtime Fabric running on VMs / Bare Metal, the backup process also includes
 Before performing a backup or restore operation:
 
 * Verify that Runtime Fabric is installed and running successfully.
-* Verify that `rtfctl` CLI tool is upgraded to version 0.3.95 or later. Verify the version by running `rtfctl version` on a Runtime Fabric node.
+* Verify that `rtfctl` CLI tool is upgraded to version 0.3.99 or later. Verify the version by running `rtfctl version` on a Runtime Fabric node.
 * If you are using Runtime Fabric on VMs / Bare Metal, verify that Runtime Fabric is upgraded to version 1.1.1581474166 or later. See xref:release-notes::runtime-fabric/runtime-fabric-installer-release-notes.adoc[Anypoint Runtime Fabric Installer Release Notes].
 
 == Create a Backup

--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -5,7 +5,15 @@ To preserve applications in the event of system failure, confirm that Runtime Fa
 The state of Runtime Fabric is distributed across the Kubernetes cluster. Use the following procedures to back up and restore the required state necessary for all deployed applications, management services, and their configurations. Individual node backup and restore operations are not supported. 
 
 [WARNING]
-Configuration changes to deployed applications and management services made after a back up are not be restored.  
+====
+Configuration changes to deployed applications and management services made after a back up cannot not be restored.  
+====
+
+[NOTE]
+====
+For Runtime Fabric running on VMs / Bare Metal, the backup process also includes backing up of undeneath Kubernetes appliance related custom resources [logforwarder, smtp, alert and alerttarget].  
+====
+
 
 == Prerequisites for Runtime Fabric
 
@@ -38,22 +46,31 @@ For Runtime Fabric running on Self-Managed Kubernetes, confirm that the `rtfctl`
 
 == Restore a Cluster
 
-To restore cluster on Runtime Fabric on VMs / Bare Metal from a backup, use an existing Runtime Fabric cluster or create a new Kubernetes cluster. The new cluster does not require Runtime Fabric to be installed with the same configuration (number of servers, disks, and so on) as the cluster being restored. To create a new cluster without Runtime Fabric being installed, run the Runtime Fabric installer script(s) but do not provide the fabric activation data.
-
-[WARNING]
-You must install to the same version of Runtime Fabric that you used to create the backup archive. You can not restore from an older version to a newer version of Runtime Fabric running on the cluster.
-
-. Copy backup archive file and make sure that it is available to `rtfctl.
+To restore cluster on Runtime Fabric on VMs / Bare Metal from a backup, use an existing Runtime Fabric cluster or create a new Kubernetes cluster with the same configuration (number of servers, disks, and so on) as the backed up cluster.  
 
 [NOTE]
+====
+To create a new Kubernetes cluster on VMs / Bare Metal without Runtime Fabric being installed, run the Runtime Fabric installer script(s) but do not provide the fabric activation data.
+====
+
+[WARNING]
+====
+For restoring on existing Runtime Fabric cluster, You must restore on to the same version of Runtime Fabric that you used to create the backup archive. You can not restore from an older version to a newer version of Runtime Fabric running on the cluster.
+====
+
+. Copy backup archive file and make sure that it is available to `rtfctl`.
+
+[NOTE]
+====
 For Runtime Fabric on VMs / Bare Metal, copy the compressed backup archive file to a folder in any of the controller nodes of the environment to be restored. For example You can transfer this file securely via the following command: 
 
 ----
 scp /backup-path/to-restore.tar.gz your_username@remotehost:/opt/anypoint/runtimefabric/
 ----
 
-[NOTE]
 For Runtime Fabric on Self-Managed Kubernetes, confirm that the `rtfctl` binary is present in the current directory and the Kubernetes (kubectl) context is set to the cluster you are restoring to.
+
+====
 
 . Restore the cluster from the backup archive with following command:
 +
@@ -62,13 +79,15 @@ rtfctl restore <path_to_backup_file>
 ----
 
 [WARNING]
-On the original backed up cluster, to restore into the newly created different cluster, scale down all Runtime Fabric components by running the following commands:
-
+====
+On the original backed up cluster, to restore into the newly created different cluster, scale down all Runtime Fabric components by running the following command: 
 ----
+# Confirm that your Kubernetes(kubectl) context is set to the backed up cluster
 `kubectl scale --replicas=0 -n rtf deployment.apps/agent`
 ----
+====
 
-Confirm that your Kubernetes(kubectl) context is set to the backed up cluster. This process may require several minutes to complete.
+This process may require several minutes to complete.
 
 == See Also
 

--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -35,7 +35,7 @@ This command creates an archive of the current system state in `<path_to_backup_
 
 [NOTE]
 ====
-For Runtime Fabric running on VMs / Bare Metal, The `rtfctl` binary is present in directory `/opt/anypoint/runtimefabric/`. Confirm that you run the backup command on any controller node in the cluster as a privileged user. To use the archive for restoring later, Copy the archive file to secure storage that is on different machine and is not part of the RTF cluster. The following command, for example, uses `scp` to copy the archive to another drive: 
+For Runtime Fabric running on VMs / Bare Metal, the `rtfctl` binary is present in directory `/opt/anypoint/runtimefabric/`. Confirm that you run the backup command on any controller node in the cluster as a privileged user. To use the archive for restoring later, copy the archive file to secure storage that is on a different machine and is not part of the RTF cluster. The following command, for example, uses `scp` to copy the archive to another drive: 
 
 ----
 scp your_username@remotehost:/opt/anypoint/runtimefabric/backup.tar.gz /backup-path/to-restore.tar.gz
@@ -55,14 +55,14 @@ To create a new Kubernetes cluster on VMs / Bare Metal without Runtime Fabric be
 
 [WARNING]
 ====
-For restoring on existing Runtime Fabric cluster, You must restore on to the same version of Runtime Fabric that you used to create the backup archive. You can not restore from an older version to a newer version of Runtime Fabric running on the cluster.
+For restoring on existing Runtime Fabric cluster, you must restore on to the same version of Runtime Fabric that you used to create the backup archive. You cannot restore from an older version to a newer version of Runtime Fabric running on the cluster.
 ====
 
 . Copy backup archive file and make sure that it is available to `rtfctl`.
 
 [NOTE]
 ====
-For Runtime Fabric on VMs / Bare Metal, copy the compressed backup archive file to a folder in any of the controller nodes of the environment to be restored. For example You can transfer this file securely via the following command: 
+For Runtime Fabric on VMs / Bare Metal, copy the compressed backup archive file to a folder in any of the controller nodes of the environment to be restored. For example, you can transfer this file securely via the following command: 
 
 ----
 scp /backup-path/to-restore.tar.gz your_username@remotehost:/opt/anypoint/runtimefabric/

--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -63,13 +63,15 @@ For Runtime Fabric on Self-Managed Kubernetes, confirm that the `rtfctl` binary 
 rtfctl restore <path_to_backup_file>
 ----
 
-. On the original backed up cluster, to restore into the new cluster, scale down all Runtime Fabric components by running the following command:
+Only for restoring on to newly created cluster, on the original backed up cluster, we need scale down all Runtime Fabric components by running the following command:
 +
 ----
 kubectl scale --replicas=0 -n rtf deployment.apps/agent
 ----
 +
-This command confirms that your Kubernetes(kubectl) context is set to the backed up cluster. This process may require several minutes to complete.
+Please confirm that your Kubernetes(kubectl) context is set to the backed up cluster before executing the above command.
+
+Runtime Fabric restoring process may require several minutes to complete.
 
 == See Also
 

--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -26,7 +26,7 @@ Before performing a backup or restore operation:
 == Create a Backup
 
 To create a backup run the following command:
-+
+
 ----
 ./rtfctl backup <path_to_backup_file>
 ----
@@ -46,7 +46,7 @@ For Runtime Fabric running on Self-Managed Kubernetes, confirm that the `rtfctl`
 
 == Restore a Cluster
 
-To restore cluster on Runtime Fabric on VMs / Bare Metal from a backup, use an existing Runtime Fabric cluster or create a new Kubernetes cluster with the same configuration (number of servers, disks, and so on) as the backed up cluster.  
+To restore cluster on Runtime Fabric from a backup, use an existing Runtime Fabric cluster or create a new Kubernetes cluster with the same configuration (number of servers, disks, and so on) as the backed up cluster.  
 
 [NOTE]
 ====
@@ -58,7 +58,7 @@ To create a new Kubernetes cluster on VMs / Bare Metal without Runtime Fabric be
 For restoring on existing Runtime Fabric cluster, You must restore on to the same version of Runtime Fabric that you used to create the backup archive. You can not restore from an older version to a newer version of Runtime Fabric running on the cluster.
 ====
 
-1. Copy backup archive file and make sure that it is available to `rtfctl`.
+. Copy backup archive file and make sure that it is available to `rtfctl`.
 
 [NOTE]
 ====
@@ -72,7 +72,7 @@ For Runtime Fabric on Self-Managed Kubernetes, confirm that the `rtfctl` binary 
 
 ====
 
-2. Restore the cluster from the backup archive with following command:
+. Restore the cluster from the backup archive with following command:
 +
 ----
 rtfctl restore <path_to_backup_file>

--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -2,7 +2,7 @@
 
 To preserve applications in the event of system failure, confirm that Runtime Fabric is automatically backed up. When scheduling backups, follow best practices by configuring hourly backups. Store your backup archive on external storage outside the Runtime Fabric cluster.
 
-The state of Runtime Fabric is distributed across the Kubernetes cluster. Use the following procedures to back up and restore the required state necessary for all deployed applications, management services, and their configurations. Individual node backup and restore operations are not supported. 
+The state of Runtime Fabric is distributed across the Kubernetes cluster. Use the following procedures to back up and restore the required state necessary for all deployed applications, management services, and their configurations. Individual Kubernetes node VM snapshot backup/restore is currently not supported. 
 
 [WARNING]
 ====

--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -13,7 +13,7 @@ Configuration changes to deployed applications and management services made afte
 For Runtime Fabric on VMs / Bare Metal, the backup and restore process also includes backing up and restoring of underneath Kubernetes appliance related custom resources [logforwarder and smtp].
 
 
-== Prerequisites for Runtime Fabric
+== Prerequisites for Backing Up Runtime Fabric
 
 Before performing a backup or restore operation:
 
@@ -31,38 +31,45 @@ To create a backup run the following command:
 
 This command creates an archive of the current system state in `<path_to_backup_file>`, which can be any path in the file system that you have write access to, for instance `/opt/anypoint/runtimefabric/backup.tar.gz`. 
 
-For Runtime Fabric on VMs / Bare Metal, the `rtfctl` binary is present in directory `/opt/anypoint/runtimefabric/`. Confirm that you run the backup command on any controller node in the cluster as a privileged user. To use the archive for restoring later, copy the archive file to secure storage that is on a different machine and is not part of the Runtime Fabric cluster. The following command, for example, uses `scp` to copy the archive to another drive: 
-
+* For Runtime Fabric on VMs / Bare Metal, the `rtfctl` binary is present in directory `/opt/anypoint/runtimefabric/`. Confirm that you run the backup command on any controller node in the cluster as a privileged user. To use the archive for restoring later, copy the archive file to secure storage that is on a different machine and is not part of the Runtime Fabric cluster. The following command, for example, uses `scp` to copy the archive to another drive: 
++
 ----
 scp your_username@remotehost:/opt/anypoint/runtimefabric/backup.tar.gz /backup-path/to-restore.tar.gz
 ----
 
-For Runtime Fabric on Self-Managed Kubernetes, confirm that the `rtfctl` binary is present in the current directory and Kubernetes(kubectl) context is set to the intended backup cluster.
+* For Runtime Fabric on Self-Managed Kubernetes, confirm that the `rtfctl` binary is present in the current directory and Kubernetes (kubectl) context is set to the intended backup cluster.
 
 == Restore a Cluster
 
-To restore Runtime Fabric cluster from a backup, use an existing Runtime Fabric cluster or create a new Kubernetes cluster with the same configuration (number of servers, disks, and so on) as the backed up cluster.  
+Runtime Fabric provides two target options when restoring a cluster from a backup:
+
+* Use an existing Runtime Fabric cluster.
+* Create a new Kubernetes cluster with the same configuration as the backed up cluster. This includes the same number of servers, disks, etc.
 
 To create a new Kubernetes cluster on VMs / Bare Metal without Runtime Fabric being installed, run the Runtime Fabric installer script(s) but do not provide the fabric activation data.
 
+[WARNING]
+====
 For restoring on existing Runtime Fabric cluster, you must restore on to the same version of Runtime Fabric that you used to create the backup archive. You cannot restore from an older version to a newer version of Runtime Fabric running on the cluster.
+====
 
 . Copy backup archive file and make sure that it is available to `rtfctl`.
 +
-For Runtime Fabric on VMs / Bare Metal, copy the compressed backup archive file to a folder in any of the controller nodes of the environment to be restored. For example, you can transfer this file securely via the following command: 
+* For Runtime Fabric on VMs / Bare Metal, copy the compressed backup archive file to a folder in any of the controller nodes of the environment to be restored. For example, you can transfer this file securely via the following command: 
 +
 ----
 scp /backup-path/to-restore.tar.gz your_username@remotehost:/opt/anypoint/runtimefabric/
 ----
 
-. Restore the cluster.
-+
-Only if restoring on to newly created cluster, on the original backed up cluster, we need to scale down all Runtime Fabric components by running the following command:
+. If you are restoring to a newly created cluster that is located on the original backed up cluster, you must first scale down all Runtime Fabric components by running the following command:
 +
 ----
 kubectl scale --replicas=0 -n rtf deployment.apps/agent
 ----
-Please confirm that your Kubernetes(kubectl) context is set to the backed up cluster before executing the above command.
++
+Confirm that your Kubernetes(kubectl) context is set to the backed up cluster before executing the above command.
+
+. Restore the cluster.
 +
 To restore the cluster from the backup archive, run the following command: 
 +

--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -20,7 +20,7 @@ For Runtime Fabric running on VMs / Bare Metal, the backup process also includes
 Before performing a backup or restore operation:
 
 * Verify that Runtime Fabric is installed and running successfully.
-* Verify that `rtfctl` CLI tool is upgraded to version 0.3.99 or later. Verify the version by running `rtfctl version` on a Runtime Fabric node.
+* Verify that `rtfctl` CLI tool is upgraded to version 0.3.102 or later. Verify the version by running `rtfctl version` on a Runtime Fabric node.
 * If you are using Runtime Fabric on VMs / Bare Metal, verify that Runtime Fabric is upgraded to version 1.1.1581474166 or later. See xref:release-notes::runtime-fabric/runtime-fabric-installer-release-notes.adoc[Anypoint Runtime Fabric Installer Release Notes].
 
 == Create a Backup

--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -54,8 +54,6 @@ For Runtime Fabric on VMs / Bare Metal, copy the compressed backup archive file 
 ----
 scp /backup-path/to-restore.tar.gz your_username@remotehost:/opt/anypoint/runtimefabric/
 ----
-+
-For Runtime Fabric on Self-Managed Kubernetes, confirm that the `rtfctl` binary is present in the current directory and the Kubernetes (kubectl) context is set to the cluster you are restoring to.
 
 . Restore the cluster.
 +
@@ -69,8 +67,10 @@ Please confirm that your Kubernetes(kubectl) context is set to the backed up clu
 To restore the cluster from the backup archive, run the following command: 
 +
 ----
-rtfctl restore <path_to_backup_file>
+./rtfctl restore <path_to_backup_file>
 ----
++
+For Runtime Fabric on Self-Managed Kubernetes, confirm that the `rtfctl` binary is present in the current directory and the Kubernetes (kubectl) context is set to the cluster you are restoring to.
 +
 This process may require several minutes to complete.
 

--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -57,16 +57,16 @@ scp /backup-path/to-restore.tar.gz your_username@remotehost:/opt/anypoint/runtim
 +
 For Runtime Fabric on Self-Managed Kubernetes, confirm that the `rtfctl` binary is present in the current directory and the Kubernetes (kubectl) context is set to the cluster you are restoring to.
 
-. Restore the cluster from the backup archive.
+. Restore the cluster.
 +
-Only for restoring on to newly created cluster, on the original backed up cluster, we need scale down all Runtime Fabric components by running the following command:
+Only if restoring on to newly created cluster, on the original backed up cluster, we need scale down all Runtime Fabric components by running the following command:
 +
 ----
 kubectl scale --replicas=0 -n rtf deployment.apps/agent
 ----
 Please confirm that your Kubernetes(kubectl) context is set to the backed up cluster before executing the above command.
 +
-To restore the cluster from the backup archive with following command: 
+To restore the cluster from the backup archive, run the following command: 
 +
 ----
 rtfctl restore <path_to_backup_file>

--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -11,7 +11,7 @@ Configuration changes to deployed applications and management services made afte
 
 [NOTE]
 ====
-For Runtime Fabric running on VMs / Bare Metal, the backup process also includes backing up of undeneath Kubernetes appliance related custom resources [logforwarder, smtp, alert and alerttarget].  
+For Runtime Fabric running on VMs / Bare Metal, the backup process also includes backing up of underneath Kubernetes appliance related custom resources [logforwarder, smtp, alert and alerttarget].  
 ====
 
 

--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -1,58 +1,59 @@
 = Back up and Restore Runtime Fabric
 
-To preserve applications in the event of system failure, ensure that Runtime Fabric is automatically backed up. MuleSoft highly recommends configuring hourly backups. Store your backup archive on external storage outside 
-the Runtime Fabric cluster.
+To preserve applications in the event of system failure, confirm that Runtime Fabric is automatically backed up. When scheduling backups, follow best practices by configuring hourly backups. Store your backup archive on external storage outside the Runtime Fabric cluster.
 
-[NOTE]
-The state of Runtime Fabric is distributed across its Kubernetes cluster. Use the following procedures to back up and restore the required state necessary for all deployed applications, management services, and their configurations. 
-Individual node backup and restore operations are not supported. 
+The state of Runtime Fabric is distributed across the Kubernetes cluster. Use the following procedures to back up and restore the required state necessary for all deployed applications, management services, and their configurations. Individual node backup and restore operations are not supported. 
 
 [WARNING]
-Any Runtime Fabric configuration changes for deployed applications and management services after back up will not be restored.  
+Configuration changes to deployed applications and management services made after a back up are not be restored.  
 
 == Prerequisites for Runtime Fabric
 
-Before performing a backup or restore operation, 
-- Verify that Runtime Fabric is installed and running successfully.
-- Verify that rtfctl CLI tool is upgraded to version 0.3.95 or later. The versions can be verified by running `rtfctl version` on a Runtime Fabric node.
-- For VMs / Bare Metal, Verify that Runtime Fabric is upgraded using  https://docs.mulesoft.com/release-notes/runtime-fabric/runtime-fabric-installer-release-notes[installer version 1.1.1581474166, role=external, window=_blank] or later 
+Before performing a backup or restore operation:
+
+* Verify that Runtime Fabric is installed and running successfully.
+* Verify that `rtfctl` CLI tool is upgraded to version 0.3.95 or later. Verify the version by running `rtfctl version` on a Runtime Fabric node.
+* If you are using Runtime Fabric on VMs / Bare Metal, verify that Runtime Fabric is upgraded to version 1.1.1581474166 or later. See xref:release-notes::runtime-fabric/runtime-fabric-installer-release-notes.adoc[Anypoint Runtime Fabric Installer Release Notes].
 
 == Create a Backup
 
-To create a backup:
-
-. Run the following command:
+To create a backup run the following command:
 +
 ----
 ./rtfctl backup <path_to_backup_file>
 ----
+
 This command creates an archive of the current system state in `<path_to_backup_file>`, which can be any path in the file system that you have write access to, for instance `/opt/anypoint/runtimefabric/backup.tar.gz`. 
 
 [NOTE]
-For Runtime Fabric running on VMs / Bare Metal, The rtfctl binary is present in directory `/opt/anypoint/runtimefabric/`. The above command should be run on any controller node in the cluster as a privileged user. To use the archive for restoring later, Copy the archive file to secure storage (a different machine that is not part of the RTF cluster);
-for example: scp your_username@remotehost:/opt/anypoint/runtimefabric/backup.tar.gz /backup-path/to-restore.tar.gz
+====
+For Runtime Fabric running on VMs / Bare Metal, The `rtfctl` binary is present in directory `/opt/anypoint/runtimefabric/`. Confirm that you run the backup command on any controller node in the cluster as a privileged user. To use the archive for restoring later, Copy the archive file to secure storage that is on different machine and is not part of the RTF cluster. The following command, for example, uses `scp` to copy the archive to another drive: 
 
-[NOTE]
-For Runtime Fabric running on Self-Managed Kubernetes, Make sure rtfctl binary is present in current directory and Kubernetes(kubectl) context is set to the intended backup cluster 
+----
+scp your_username@remotehost:/opt/anypoint/runtimefabric/backup.tar.gz /backup-path/to-restore.tar.gz
+----
 
+For Runtime Fabric running on Self-Managed Kubernetes, confirm that the `rtfctl` binary is present in the current directory and Kubernetes(kubectl) context is set to the intended backup cluster.
+====
 
 == Restore a Cluster
 
-To restore a Runtime Fabric cluster from a backup, you can use the existing Runtime Fabric cluster or create a new Kubernetes cluster with/without Runtime Fabric installed with the same hardware (number of servers, disks, and so on) as the cluster being restored.
-
-[NOTE]
-To create a new VMs / Bare Metal Kubernetes cluster without runtime fabric installed, Use Runtime Fabric installer script(s) without providing the fabric activation data.
+To restore cluster on Runtime Fabric on VMs / Bare Metal from a backup, use an existing Runtime Fabric cluster or create a new Kubernetes cluster. The new cluster does not require Runtime Fabric to be installed with the same configuration (number of servers, disks, and so on) as the cluster being restored. To create a new cluster without Runtime Fabric being installed, run the Runtime Fabric installer script(s) but do not provide the fabric activation data.
 
 [WARNING]
-You can not restore Runtime Fabric on a newer version of the Runtime Fabric cluster. The new installation must use the same version of Runtime Fabric installation bundle as the backup.
+You must install to the same version of Runtime Fabric that you used to create the backup archive. You can not restore from an older version to a newer version of Runtime Fabric running on the cluster.
 
-. Copy and make sure that backup archive file is available for rtfctl.
-
-[NOTE]
-For Runtime Fabric running on VMs / Bare Metal, Copy the compressed backup archive file to a folder in any of the controller nodes of the environment to be restored. For example You can transfer this file securely via the following command: scp /backup-path/to-restore.tar.gz your_username@remotehost:/opt/anypoint/runtimefabric/
+. Copy backup archive file and make sure that it is available to `rtfctl.
 
 [NOTE]
-For Runtime Fabric running on Self-Managed Kubernetes, Make sure rtfctl binary is present in current directory and Kubernetes(kubectl) context is set to the intended restore cluster
+For Runtime Fabric on VMs / Bare Metal, copy the compressed backup archive file to a folder in any of the controller nodes of the environment to be restored. For example You can transfer this file securely via the following command: 
+
+----
+scp /backup-path/to-restore.tar.gz your_username@remotehost:/opt/anypoint/runtimefabric/
+----
+
+[NOTE]
+For Runtime Fabric on Self-Managed Kubernetes, confirm that the `rtfctl` binary is present in the current directory and the Kubernetes (kubectl) context is set to the cluster you are restoring to.
 
 . Restore the cluster from the backup archive with following command:
 +
@@ -61,9 +62,13 @@ rtfctl restore <path_to_backup_file>
 ----
 
 [WARNING]
-On the original backed up cluster, If we plan to restore into the newly created different cluster, we will need to scale down all the runtime fabric components by running the following commands: `kubectl scale --replicas=0 -n rtf deployment.apps/agent` ( Make sure your Kubernetes(kubectl) context is set to the backed up cluster).
+On the original backed up cluster, to restore into the newly created different cluster, scale down all Runtime Fabric components by running the following commands:
 
-This process requires a few minutes.
+----
+`kubectl scale --replicas=0 -n rtf deployment.apps/agent`
+----
+
+Confirm that your Kubernetes(kubectl) context is set to the backed up cluster. This process may require several minutes to complete.
 
 == See Also
 

--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -11,7 +11,7 @@ Configuration changes to deployed applications and management services made afte
 
 [NOTE]
 ====
-For Runtime Fabric running on VMs / Bare Metal, the backup process also includes backing up of underneath Kubernetes appliance related custom resources [logforwarder, smtp, alert and alerttarget].  
+For Runtime Fabric running on VMs / Bare Metal, the backup process also includes backing up of underneath Kubernetes appliance related custom resources [logforwarder and smtp].  
 ====
 
 
@@ -35,13 +35,13 @@ This command creates an archive of the current system state in `<path_to_backup_
 
 [NOTE]
 ====
-For Runtime Fabric running on VMs / Bare Metal, the `rtfctl` binary is present in directory `/opt/anypoint/runtimefabric/`. Confirm that you run the backup command on any controller node in the cluster as a privileged user. To use the archive for restoring later, copy the archive file to secure storage that is on a different machine and is not part of the RTF cluster. The following command, for example, uses `scp` to copy the archive to another drive: 
+For Runtime Fabric on VMs / Bare Metal, the `rtfctl` binary is present in directory `/opt/anypoint/runtimefabric/`. Confirm that you run the backup command on any controller node in the cluster as a privileged user. To use the archive for restoring later, copy the archive file to secure storage that is on a different machine and is not part of the Runtime Fabric cluster. The following command, for example, uses `scp` to copy the archive to another drive: 
 
 ----
 scp your_username@remotehost:/opt/anypoint/runtimefabric/backup.tar.gz /backup-path/to-restore.tar.gz
 ----
 
-For Runtime Fabric running on Self-Managed Kubernetes, confirm that the `rtfctl` binary is present in the current directory and Kubernetes(kubectl) context is set to the intended backup cluster.
+For Runtime Fabric on Self-Managed Kubernetes, confirm that the `rtfctl` binary is present in the current directory and Kubernetes(kubectl) context is set to the intended backup cluster.
 ====
 
 == Restore a Cluster

--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -61,7 +61,7 @@ For restoring on existing Runtime Fabric cluster, you must restore on to the sam
 scp /backup-path/to-restore.tar.gz your_username@remotehost:/opt/anypoint/runtimefabric/
 ----
 
-. If you are restoring to a newly created cluster that is located on the original backed up cluster, you must first scale down all Runtime Fabric components by running the following command:
+. If you are restoring to a newly created cluster, you must first scale down all Runtime Fabric components on the original, backed-up cluster by running the following command:
 +
 ----
 kubectl scale --replicas=0 -n rtf deployment.apps/agent

--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -64,11 +64,9 @@ rtfctl restore <path_to_backup_file>
 ----
 
 Only for restoring on to newly created cluster, on the original backed up cluster, we need scale down all Runtime Fabric components by running the following command:
-+
 ----
 kubectl scale --replicas=0 -n rtf deployment.apps/agent
 ----
-+
 Please confirm that your Kubernetes(kubectl) context is set to the backed up cluster before executing the above command.
 
 Runtime Fabric restoring process may require several minutes to complete.

--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -59,7 +59,7 @@ For Runtime Fabric on Self-Managed Kubernetes, confirm that the `rtfctl` binary 
 
 . Restore the cluster.
 +
-Only if restoring on to newly created cluster, on the original backed up cluster, we need scale down all Runtime Fabric components by running the following command:
+Only if restoring on to newly created cluster, on the original backed up cluster, we need to scale down all Runtime Fabric components by running the following command:
 +
 ----
 kubectl scale --replicas=0 -n rtf deployment.apps/agent

--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -9,10 +9,8 @@ The state of Runtime Fabric is distributed across the Kubernetes cluster. Use th
 Configuration changes to deployed applications and management services made after a back up cannot not be restored.  
 ====
 
-[NOTE]
-====
-For Runtime Fabric on VMs / Bare Metal, the backup and restore process also includes backing up and restoring of underneath Kubernetes appliance related custom resources [logforwarder and smtp].  
-====
+
+For Runtime Fabric on VMs / Bare Metal, the backup and restore process also includes backing up and restoring of underneath Kubernetes appliance related custom resources [logforwarder and smtp].
 
 
 == Prerequisites for Runtime Fabric
@@ -33,8 +31,6 @@ To create a backup run the following command:
 
 This command creates an archive of the current system state in `<path_to_backup_file>`, which can be any path in the file system that you have write access to, for instance `/opt/anypoint/runtimefabric/backup.tar.gz`. 
 
-[NOTE]
-====
 For Runtime Fabric on VMs / Bare Metal, the `rtfctl` binary is present in directory `/opt/anypoint/runtimefabric/`. Confirm that you run the backup command on any controller node in the cluster as a privileged user. To use the archive for restoring later, copy the archive file to secure storage that is on a different machine and is not part of the Runtime Fabric cluster. The following command, for example, uses `scp` to copy the archive to another drive: 
 
 ----
@@ -42,35 +38,24 @@ scp your_username@remotehost:/opt/anypoint/runtimefabric/backup.tar.gz /backup-p
 ----
 
 For Runtime Fabric on Self-Managed Kubernetes, confirm that the `rtfctl` binary is present in the current directory and Kubernetes(kubectl) context is set to the intended backup cluster.
-====
 
 == Restore a Cluster
 
 To restore Runtime Fabric cluster from a backup, use an existing Runtime Fabric cluster or create a new Kubernetes cluster with the same configuration (number of servers, disks, and so on) as the backed up cluster.  
 
-[NOTE]
-====
 To create a new Kubernetes cluster on VMs / Bare Metal without Runtime Fabric being installed, run the Runtime Fabric installer script(s) but do not provide the fabric activation data.
-====
 
-[WARNING]
-====
 For restoring on existing Runtime Fabric cluster, you must restore on to the same version of Runtime Fabric that you used to create the backup archive. You cannot restore from an older version to a newer version of Runtime Fabric running on the cluster.
-====
 
 . Copy backup archive file and make sure that it is available to `rtfctl`.
-
-[NOTE]
-====
++
 For Runtime Fabric on VMs / Bare Metal, copy the compressed backup archive file to a folder in any of the controller nodes of the environment to be restored. For example, you can transfer this file securely via the following command: 
-
++
 ----
 scp /backup-path/to-restore.tar.gz your_username@remotehost:/opt/anypoint/runtimefabric/
 ----
-
++
 For Runtime Fabric on Self-Managed Kubernetes, confirm that the `rtfctl` binary is present in the current directory and the Kubernetes (kubectl) context is set to the cluster you are restoring to.
-
-====
 
 . Restore the cluster from the backup archive with following command:
 +
@@ -78,16 +63,13 @@ For Runtime Fabric on Self-Managed Kubernetes, confirm that the `rtfctl` binary 
 rtfctl restore <path_to_backup_file>
 ----
 
-[WARNING]
-====
-On the original backed up cluster, to restore into the newly created different cluster, scale down all Runtime Fabric components by running the following command: 
+. On the original backed up cluster, to restore into the new cluster, scale down all Runtime Fabric components by running the following command:
++
 ----
-# Confirm that your Kubernetes(kubectl) context is set to the backed up cluster
-`kubectl scale --replicas=0 -n rtf deployment.apps/agent`
+kubectl scale --replicas=0 -n rtf deployment.apps/agent
 ----
-====
-
-This process may require several minutes to complete.
++
+This command confirms that your Kubernetes(kubectl) context is set to the backed up cluster. This process may require several minutes to complete.
 
 == See Also
 

--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -58,7 +58,7 @@ To create a new Kubernetes cluster on VMs / Bare Metal without Runtime Fabric be
 For restoring on existing Runtime Fabric cluster, You must restore on to the same version of Runtime Fabric that you used to create the backup archive. You can not restore from an older version to a newer version of Runtime Fabric running on the cluster.
 ====
 
-. Copy backup archive file and make sure that it is available to `rtfctl`.
+1. Copy backup archive file and make sure that it is available to `rtfctl`.
 
 [NOTE]
 ====
@@ -72,7 +72,7 @@ For Runtime Fabric on Self-Managed Kubernetes, confirm that the `rtfctl` binary 
 
 ====
 
-. Restore the cluster from the backup archive with following command:
+2. Restore the cluster from the backup archive with following command:
 +
 ----
 rtfctl restore <path_to_backup_file>

--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -1,61 +1,67 @@
 = Back up and Restore Runtime Fabric
 
-To preserve applications in the event of system failure, ensure that Runtime Fabric is automatically backed up. 
-MuleSoft highly recommends configuring hourly backups. Store your backup archive on external storage outside 
+To preserve applications in the event of system failure, ensure that Runtime Fabric is automatically backed up. MuleSoft highly recommends configuring hourly backups. Store your backup archive on external storage outside 
 the Runtime Fabric cluster.
 
 [NOTE]
-The state of Runtime Fabric is distributed across its controller nodes. Use the following procedures to back up and restore
-the required state necessary for all deployed applications, management services, and their configurations. 
-Individual node backup and restore operations are not supported.
+The state of Runtime Fabric is distributed across its Kubernetes cluster. Use the following procedures to back up and restore the required state necessary for all deployed applications, management services, and their configurations. 
+Individual node backup and restore operations are not supported. 
 
+[WARNING]
+Any Runtime Fabric configuration changes for deployed applications and management services after back up will not be restored.  
 
-== Prerequisites for Runtime Fabric on VMs / Bare Metal
+== Prerequisites for Runtime Fabric
 
-Before performing a backup or restore operation, verify that Runtime Fabric on VMs / Bare Metal was installed or upgraded 
-using  https://docs.mulesoft.com/release-notes/runtime-fabric/runtime-fabric-installer-release-notes[installer version 1.1.1581474166, role=external, window=_blank] or later, and that the rtfctl CLI tool is upgraded to version 0.2.95 or later. The versions can be verified by running `rtfctl version` on a Runtime Fabric node.
+Before performing a backup or restore operation, 
+- Verify that Runtime Fabric is installed and running successfully.
+- Verify that rtfctl CLI tool is upgraded to version 0.3.95 or later. The versions can be verified by running `rtfctl version` on a Runtime Fabric node.
+- For VMs / Bare Metal, Verify that Runtime Fabric is upgraded using  https://docs.mulesoft.com/release-notes/runtime-fabric/runtime-fabric-installer-release-notes[installer version 1.1.1581474166, role=external, window=_blank] or later 
 
 == Create a Backup
 
 To create a backup:
 
-. Run the following command on any controller node in the cluster as a privileged user (with root access):
+. Run the following command:
 +
 ----
 ./rtfctl backup <path_to_backup_file>
 ----
 This command creates an archive of the current system state in `<path_to_backup_file>`, which can be any path in the file system that you have write access to, for instance `/opt/anypoint/runtimefabric/backup.tar.gz`. 
 
-. Move the archive file to secure storage (a different machine that is not part of the RTF cluster);
-for example:
-+
-----
-scp your_username@remotehost:/opt/anypoint/runtimefabric/backup.tar.gz /backup-path/to-restore.tar.gz
-----
+[NOTE]
+For Runtime Fabric running on VMs / Bare Metal, The rtfctl binary is present in directory `/opt/anypoint/runtimefabric/`. The above command should be run on any controller node in the cluster as a privileged user. To use the archive for restoring later, Copy the archive file to secure storage (a different machine that is not part of the RTF cluster);
+for example: scp your_username@remotehost:/opt/anypoint/runtimefabric/backup.tar.gz /backup-path/to-restore.tar.gz
+
+[NOTE]
+For Runtime Fabric running on Self-Managed Kubernetes, Make sure rtfctl binary is present in current directory and Kubernetes(kubectl) context is set to the intended backup cluster 
+
 
 == Restore a Cluster
 
-To restore a Runtime Fabric cluster from a backup, you can use the existing Runtime Fabric cluster or create a new Runtime Fabric 
-cluster with the same hardware (number of servers, disks, and so on) as the cluster being restored.
+To restore a Runtime Fabric cluster from a backup, you can use the existing Runtime Fabric cluster or create a new Kubernetes cluster with/without Runtime Fabric installed with the same hardware (number of servers, disks, and so on) as the cluster being restored.
+
+[NOTE]
+To create a new VMs / Bare Metal Kubernetes cluster without runtime fabric installed, Use Runtime Fabric installer script(s) without providing the fabric activation data.
 
 [WARNING]
-You can not restore Runtime Fabric on a newer version of the Runtime Fabric cluster. The new installation must use 
-the same version of Runtime Fabric installation bundle as the backup.
+You can not restore Runtime Fabric on a newer version of the Runtime Fabric cluster. The new installation must use the same version of Runtime Fabric installation bundle as the backup.
 
-. Log in to a controller node in your Runtime Fabric as a privileged user (with root access).
+. Copy and make sure that backup archive file is available for rtfctl.
 
-. Move the compressed backup archive file to a folder in any of the controller nodes of the environment to be restored. 
-You can transfer this file securely via the following command:
+[NOTE]
+For Runtime Fabric running on VMs / Bare Metal, Copy the compressed backup archive file to a folder in any of the controller nodes of the environment to be restored. For example You can transfer this file securely via the following command: scp /backup-path/to-restore.tar.gz your_username@remotehost:/opt/anypoint/runtimefabric/
+
+[NOTE]
+For Runtime Fabric running on Self-Managed Kubernetes, Make sure rtfctl binary is present in current directory and Kubernetes(kubectl) context is set to the intended restore cluster
+
+. Restore the cluster from the backup archive with following command:
 +
 ----
-scp /backup-path/to-restore.tar.gz your_username@remotehost:/opt/anypoint/runtimefabric/
+rtfctl restore <path_to_backup_file>
 ----
 
-. Restore the cluster from the backup archive:
-+
-----
-rtfctl restore /opt/anypoint/runtimefabric/to-restore.tar.gz
-----
+[WARNING]
+On the original backed up cluster, If we plan to restore into the newly created different cluster, we will need to scale down all the runtime fabric components by running the following commands: `kubectl scale --replicas=0 -n rtf deployment.apps/agent` ( Make sure your Kubernetes(kubectl) context is set to the backed up cluster).
 
 This process requires a few minutes.
 


### PR DESCRIPTION
As part rtfctl back up and restore feature, We want to include the following in the public documentation, 

- Current documentation should include common procedure for backup and restore for both BYOK and  Appliance Clusters. 
- Documentation common procedure needs to include a section for scaling down/stopping the original cluster before restoring it to a new cluster.
- Separate out notes for changes/assumptions for backup and restore on BYOK and Appliance Clusters 