### PR TITLE
AWS Application Load Balancer

### DIFF
--- a/modules/ROOT/pages/custom-ingress-configuration.adoc
+++ b/modules/ROOT/pages/custom-ingress-configuration.adoc
@@ -392,4 +392,4 @@ The results should be similar to:
 
 Scenario: When using an AWS ALB, you can’t access an application’s endpoint, even though you successfully deployed the application and endpoint. 
 
-If you’re using AWS Load Balancer Controller for ingress, you must specify the `kubernetes.io/ingress.class: alb` annotation in the template, _not_ `ingressClassName: alb`. AWS Load Balancer Controller requires the `ingress.class` annotation to discover and create L7 load balancers for deployed ingress resources for those annotations.
+If you’re using AWS Load Balancer Controller for ingress, you must specify the `kubernetes.io/ingress.class: rtf-alb` annotation in the template, _not_ `ingressClassName: rtf-alb`. AWS Load Balancer Controller requires the `ingress.class` annotation to discover and create L7 load balancers for deployed ingress resources for those annotations.


### PR DESCRIPTION
Added the rtf- prefix because it was confusing the users when setting the template for AWS.