### PR TITLE
cherry-pick  from W-10853919

### DIFF
--- a/modules/ROOT/pages/install-rtfctl.adoc
+++ b/modules/ROOT/pages/install-rtfctl.adoc
@@ -81,16 +81,29 @@ Performs operations on the Runtime Fabric appliance
 rtfctl appliance apply alert-smtp-from "<sender>@<domain>.com"
 ----
 
-* Renews an expired client certificate using a pre-downloaded package
-+
-----
-rtfctl appliance renew-expired-client-certificate --file <cert-bundle-filename>
-----
 
 * Renews an expired client certificate by downloading the certificate bundle
 +
 ----
-rtfctl appliance renew-expired-client-certificate --auth '<YOUR ANYPOINT AUTHORIZATION TOKEN>' --url 'https://<host>/<path-to-installer-package>'\
+rtfctl appliance renew-expired-client-cert --auth '<YOUR ANYPOINT AUTHORIZATION TOKEN>' --url 'https://anypoint.mulesoft.com/runtimefabric/api/organizations/<org-id>/fabrics/<fabric-id>/certificate-bundle'
+----
+
+* Renews an expired client certificate using a pre-downloaded package
++
+----
+rtfctl appliance renew-expired-client-cert --file <cert-bundle-filename>
+----
+
+* Reinstalls Runtime Fabric components using the latest scripts
++
+----
+rtfctl appliance reinstall
+----
+
+* Reinstalls Runtime Fabric components without downloading the latest scripts
++
+----
+rtfctl appliance reinstall --skip-download
 ----
 
 * Generates an appliance diagnostics report


### PR DESCRIPTION
Corrected rtfctl appliance renew-expired-client-cert use:
 * It's renew-expired-client-cert instead of 
renew-expired-client-certificate
 * Put the two versions of the command together
 * Added a working base URL to the example that customers can complete 
and use, otherwise it's unknown where the certificate bundle comes from