### PR TITLE
Change to clarify API ingress is from API clients not internet

### DIFF
--- a/modules/ROOT/pages/install-prereqs.adoc
+++ b/modules/ROOT/pages/install-prereqs.adoc
@@ -170,7 +170,7 @@ The following table lists all ports that must be open, along with the respective
 |===
 | Port | Layer 4 Protocol | Layer 5 Protocol | Source | Destination | Description
 | 123 | UDP | NTP | All nodes | Internet | Clock synchronization via Network Time Protocol
-| 443 | TCP | HTTPS | Internet | Controller nodes | Allow inbound requests to Mules
+| 443 | TCP | HTTPS | API consumers | Controller nodes | Allow inbound API requests to ingress controllers
 | 443 | TCP | AMQP over WebSockets | Controller nodes | Internet | Anypoint Platform management services
 | 443 | TCP | HTTPS | All nodes | Internet | API Manager policy updates, API Analytics Ingestion, and Resource retrieval (application files, container images).
 | 443 (v1.8.50, or later) | TCP | Lumberjack | All nodes | Internet | Anypoint Monitoring, Anypoint Visualizer

--- a/modules/ROOT/pages/install-self-managed-network-configuration.adoc
+++ b/modules/ROOT/pages/install-self-managed-network-configuration.adoc
@@ -14,7 +14,7 @@ To install or run Runtime Fabric, ensure that you have configured the following 
 [%header%autowidth.spread]
 |===
 | Port | Layer 4 Protocol | Layer 5 Protocol | Source | Destination | Description
-| 443 | TCP | HTTPS | Internet | All nodes | Allow inbound requests to Mule runtime servers
+| 443 | TCP | HTTPS | API consumers | All nodes | Allow inbound API requests to ingress controllers
 | 443 | TCP | AMQP over WebSockets | All nodes | Internet | Anypoint Platform management services
 | 443 | TCP | HTTPS | All nodes | Internet | API Manager policy updates, API Analytics Ingestion, and Resource retrieval (application files, container images).
 | 443 (v1.8.50, or later) | TCP | Lumberjack | All nodes | Internet | Anypoint Monitoring, Anypoint Visualizer


### PR DESCRIPTION
Adjust the wording in the network/port configuration tables for both self-managed and bare-metal RTF: use of the term “Internet” as the source for “Allow inbound requests to Mule runtime servers” rightly makes many customers nervous and/or push back on the requirement. The actual requirement is for “API consumers” to have access to Mule runtimes on port 443, which may reside inside the customer network boundary. Also clarify that it is the ingress controller pod that receives these requests (although that cannot be specified in the firewall rule).

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
