### PR TITLE
w-11945616

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -178,22 +178,6 @@ Anypoint Runtime Fabric does not include external log forwarding. You are respon
 
 For Titanium customers, Anypoint Runtime Fabric supports logging using Anypoint Monitoring. See xref:monitoring::logs.adoc[Logs in Anypoint Monitoring] for more information.
 
-==== Anypoint Monitoring Log Forwarding Requisites
-
-The daemon-set forwarding logs to Anypoint Monitoring expects application containers to be writing logs to the following locations:
-
-* /var/log/pods
-* /var/log/containers
-* /var/lib/docker/containers
-
-It also creates and write on the host path `/var/lib/filebeat-data`.
-Because of this it is required for this log forwarding to work as expected that:
-
-* Docker daemon config includes the `json-file` logging driver
-* On the host, the hostPath /var/lib/filebeat-data needs to be writable by the am-log-forwarder daemon-set's container
-
-Usually this works out of the box. On hardened installations the above may not be true and cause log forwarding to fail. Make sure you are fulfilling the requisited mentioned in that case.
-
 === Monitoring
 
 xref:monitoring::index.adoc[Anypoint Monitoring] provides metrics for applications and API gateways deployed to Runtime Fabric. 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -178,6 +178,22 @@ Anypoint Runtime Fabric does not include external log forwarding. You are respon
 
 For Titanium customers, Anypoint Runtime Fabric supports logging using Anypoint Monitoring. See xref:monitoring::logs.adoc[Logs in Anypoint Monitoring] for more information.
 
+==== Anypoint Monitoring Log Forwarding Requisites
+
+The daemon-set forwarding logs to Anypoint Monitoring expects application containers to be writing logs to the following locations:
+
+* /var/log/pods
+* /var/log/containers
+* /var/lib/docker/containers
+
+It also creates and write on the host path `/var/lib/filebeat-data`.
+Because of this it is required for this log forwarding to work as expected that:
+
+* Docker daemon config includes the `json-file` logging driver
+* On the host, the hostPath /var/lib/filebeat-data needs to be writable by the am-log-forwarder daemon-set's container
+
+Usually this works out of the box. On hardened installations the above may not be true and cause log forwarding to fail. Make sure you are fulfilling the requisited mentioned in that case.
+
 === Monitoring
 
 xref:monitoring::index.adoc[Anypoint Monitoring] provides metrics for applications and API gateways deployed to Runtime Fabric. 

--- a/modules/ROOT/pages/manage-monitor-applications.adoc
+++ b/modules/ROOT/pages/manage-monitor-applications.adoc
@@ -73,6 +73,19 @@ and transmits the log data to Anypoint Monitoring.
 * You can toggle application log forwarding at the application level to Anypoint Monitoring from Runtime Fabric v1.5.25 version and later.
 ====
 
+==== Anypoint Monitoring Log Forwarding Prerequisites
+
+The daemon-set that forwards logs to Anypoint Monitoring expects application containers to write logs to the following locations:
+
+* `/var/log/pods`
+* `/var/log/containers`
+* `/var/lib/docker/containers`
+
+It also creates and writes on the host path `/var/lib/filebeat-data`. For log forwarding to work as expected, ensure that:
+
+* The Docker daemon config includes the `json-file` logging driver.
+* The Anypoint Monitoring log forwarder daemon-set container has write access to the host on the host path `/var/lib/filebeat-data`.
+
 == Anypoint Visualizer
 
 xref:visualizer::index.adoc[Anypoint Visualizer] displays views of different aspects of an application network graph. 

--- a/modules/ROOT/pages/manage-monitor-applications.adoc
+++ b/modules/ROOT/pages/manage-monitor-applications.adoc
@@ -81,7 +81,7 @@ The daemon-set that forwards logs to Anypoint Monitoring expects application con
 * `/var/log/containers`
 * `/var/lib/docker/containers`
 
-It also creates and writes on the host path `/var/lib/filebeat-data`. For log forwarding to work as expected, ensure that:
+The daemon-set also creates and writes on the host path `/var/lib/filebeat-data`. For log forwarding to work as expected, ensure that:
 
 * The Docker daemon config includes the `json-file` logging driver.
 * The Anypoint Monitoring log forwarder daemon-set container has write access to the host on the host path `/var/lib/filebeat-data`.


### PR DESCRIPTION
Following the request on GUS [W-11945616](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000019Syi9YAC/view) I have added some lines to specify these requirements that are mandatory for am-log-forwarder to work.

I have chosen this section as is part of RTF generalities, but I leave up to @IsaacEldridge where to put the content if another section makes more sense.

This is based on the issue dealt in Jira [SE-22480](https://www.mulesoft.org/jira/browse/SE-22480) and how the am-log-forwarder currently works. I wrote in a general way and avoided any specifics that would have been only relevant to that specific issue. In particular I am referring to the changes specific to SE Linux and TrendMicro antivirus. The key is the path to be writable, under any software combination.

@kmendiratta-crm I am requesting your optional review just to make you aware of this change. In particular so we don't forget to update the paths the container read from or to change this paragraphs if the feature to customize Filebeat temporary files location is released.

@rtom-mulesoft since you are the GUS creator also requesting your optional review.