### PR TITLE
[W-12522437] update support status for v1.0

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -5,4 +5,4 @@ nav:
 - modules/ROOT/nav.adoc
 asciidoc:
   attributes:
-    noLongerUpdated: true
+    supportStatus: noLongerUpdated


### PR DESCRIPTION
ref: [W-12522437](https://gus.lightning.force.com/a07EE00001L1PrGYAV)

update attribute using the new `supportStatus` method. See https://confluence.internal.salesforce.com/display/MTDT/Using+Banners for further info.