### PR TITLE
fix/w-12666340 - Added clarification on templated edits

### DIFF
--- a/modules/ROOT/pages/custom-ingress-configuration.adoc
+++ b/modules/ROOT/pages/custom-ingress-configuration.adoc
@@ -230,10 +230,10 @@ type: kubernetes.io/tls
 
 Applying this label to your secret enables your ingress controller to immediately apply the updated TLS material into application namespaces. If you don't add this label, you must manually update the secret in each namespace.
 
-== Modifying an Existing Ingress Template
+== Modify an Existing Ingress Template
 
 You can modify existing ingress templates even if they were already used for application deployments.
-Be aware that already created ingresses objects based of this template won't be updated as a consequence of modifying the template.
+Note that already created ingress objects based on this template are not updated if you modify the template.
 
 To update existing ingresses with the template changes, you have to perform a redeployment of the Mule application.
 For example, if you update the base domain which requires to change the endpoint for the ingress template, you must remove the old endpoint and add the new one as part of the application redeployment.

--- a/modules/ROOT/pages/custom-ingress-configuration.adoc
+++ b/modules/ROOT/pages/custom-ingress-configuration.adoc
@@ -230,6 +230,14 @@ type: kubernetes.io/tls
 
 Applying this label to your secret enables your ingress controller to immediately apply the updated TLS material into application namespaces. If you don't add this label, you must manually update the secret in each namespace.
 
+== Making changes to an existing Ingress Template
+
+An existing ingress template can be modified even if it has already been used for application deployments.
+A caveat you must be aware of is that already created ingresses objects based off this template won't be updated as a consecuence of this action. 
+
+If you would like for existing ingresses to be updated with the changes have to perform a redeployment of the Mule applications.
+In the event the endpoint for the ingress template has changed, for example if you are updating the base domain, you will have to remove the old enpoint and add the new one as part of this redeployment.
+
 == Configure Ingress for a Mule Application Deployment in Runtime Fabric
 
 To configure ingress, complete the following tasks:

--- a/modules/ROOT/pages/custom-ingress-configuration.adoc
+++ b/modules/ROOT/pages/custom-ingress-configuration.adoc
@@ -230,13 +230,13 @@ type: kubernetes.io/tls
 
 Applying this label to your secret enables your ingress controller to immediately apply the updated TLS material into application namespaces. If you don't add this label, you must manually update the secret in each namespace.
 
-== Making changes to an existing Ingress Template
+== Modifying an Existing Ingress Template
 
-An existing ingress template can be modified even if it has already been used for application deployments.
-A caveat you must be aware of is that already created ingresses objects based off this template won't be updated as a consecuence of this action. 
+You can modify existing ingress templates even if they were already used for application deployments.
+Be aware that already created ingresses objects based of this template won't be updated as a consequence of modifying the template.
 
-If you would like for existing ingresses to be updated with the changes have to perform a redeployment of the Mule applications.
-In the event the endpoint for the ingress template has changed, for example if you are updating the base domain, you will have to remove the old enpoint and add the new one as part of this redeployment.
+To update existing ingresses with the template changes, you have to perform a redeployment of the Mule application.
+For example, if you update the base domain which requires to change the endpoint for the ingress template, you must remove the old endpoint and add the new one as part of the application redeployment.
 
 == Configure Ingress for a Mule Application Deployment in Runtime Fabric
 


### PR DESCRIPTION
Clarified after investigation W-12663962 that this is indeed a template for ingresses objects created, not a base implementation. So already created ingresses are not affected by template updates.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
