### PR TITLE
W-16143385 – Typo in KubernetesTemplate example

### DIFF
--- a/modules/ROOT/pages/customize-kubernetes-crd.adoc
+++ b/modules/ROOT/pages/customize-kubernetes-crd.adoc
@@ -133,7 +133,7 @@ spec:
       whenUnsatisfiable: DoNotSchedule  
       labelSelector:  
         matchLabels:  
-          rtf.mulesoft.com/id: {{ .Values.id }}  
+          rtf.mulesoft.com/id: '{{ .Values.id }}'
 
 ----
 


### PR DESCRIPTION
{{ .Values.id }} should be quoted
