### PR TITLE
W-17030250: Clarify backup&restore rtfctl secure properties management

### DIFF
--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -67,7 +67,7 @@ For OpenShift clusters, the following is backed up:
 
 All changes performed on the control plane side don't need a new backup to be taken into account because those are taken from the platform at the time of restoration.
 
-Any change done on the cluster side are not part of the restoration and they need to be reapplied. These changes include:
+Any changes done on the cluster side aren't part of the restoration and must be reapplied. These changes include:
 
 * Agent upgrades
 * RTFCTL managed secure properties

--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -65,7 +65,7 @@ For OpenShift clusters, the following is backed up:
 
 === Changes Made After Performing a Backup Are Not Restored
 
-All changes performed on the control plane side do not need a new backup to be taken into account since those are taken from the platform at the time of restoration.
+All changes performed on the control plane side don't need a new backup to be taken into account because those are taken from the platform at the time of restoration.
 
 Any change done on the cluster side are not part of the restoration and they need to be reapplied. These changes include:
 

--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -4,7 +4,8 @@ Use the following procedures to back up and restore Runtime Fabric services and 
 
 Data about the state of Runtime Fabric is distributed across the Kubernetes cluster. To preserve applications in the event of system failure, confirm that Runtime Fabric is automatically backed up. When scheduling backups, follow best practices by configuring hourly backups. Store your backup on external storage outside the Runtime Fabric cluster.
 
-Starting with `rtfctl` version 1.0.70, if you use an rtf-agent version higher than 2.6.52, the `rtfctl` backup bundle does not contain the Mule app deployments. The deployments are synched from the Runtime Manager UI at the time of restoration.
+Starting with `rtfctl` version 1.0.70, if you use an rtf-agent version higher than 2.6.52, the `rtfctl` backup bundle does not contain the Mule app deployments. The deployments are synced from the Runtime Manager UI at the time of restoration. This documentation page
+describes this latest behavior.
 
 == When to Use the Back Up and Restore Process
 
@@ -65,16 +66,16 @@ For OpenShift clusters, the following is backed up:
 
 === Changes Made After Performing a Backup Are Not Restored
 
-Any changes you make after you perform a backup will not be present if you restore the cluster from that backup. For example, if you perform a backup, delete an application, and then restore from that backup, the application you deleted will be recreated in the cluster, but it will be marked as deleted in Runtime Manager. As a result the application's status will show as *applying* in Runtime Manager.
+All changes performed on the control plane side will not need a new backup to be taken into account since those are taken
+from the platform at the time of restoration.
 
-Runtime Fabric does not restore the following control plane changes if you make them after you take a backup:
+Any change done on the cluster side will not be part of the restoration and will need to be reapplied. This changes
+include:
 
-* Created apps
-* Delete apps
-* Updated app configurations
 * Agent upgrades
-
-You need to manually resolve such inconsistencies by reapplying the changes you made after performing the backup, as these changes can't be reapplied from the control plane.
+* Rtfctl managed secure properties
+* Ingress resources on rtf namespace
+* ConfigMap settings
 
 == Create a Backup
 

--- a/modules/ROOT/pages/manage-backup-restore.adoc
+++ b/modules/ROOT/pages/manage-backup-restore.adoc
@@ -4,8 +4,7 @@ Use the following procedures to back up and restore Runtime Fabric services and 
 
 Data about the state of Runtime Fabric is distributed across the Kubernetes cluster. To preserve applications in the event of system failure, confirm that Runtime Fabric is automatically backed up. When scheduling backups, follow best practices by configuring hourly backups. Store your backup on external storage outside the Runtime Fabric cluster.
 
-Starting with `rtfctl` version 1.0.70, if you use an rtf-agent version higher than 2.6.52, the `rtfctl` backup bundle does not contain the Mule app deployments. The deployments are synced from the Runtime Manager UI at the time of restoration. This documentation page
-describes this latest behavior.
+Starting with `rtfctl` version 1.0.70, if you use an rtf-agent version higher than 2.6.52, the `rtfctl` backup bundle does not contain the Mule app deployments. The deployments are synced from the Runtime Manager UI at the time of restoration.
 
 == When to Use the Back Up and Restore Process
 
@@ -66,15 +65,13 @@ For OpenShift clusters, the following is backed up:
 
 === Changes Made After Performing a Backup Are Not Restored
 
-All changes performed on the control plane side will not need a new backup to be taken into account since those are taken
-from the platform at the time of restoration.
+All changes performed on the control plane side do not need a new backup to be taken into account since those are taken from the platform at the time of restoration.
 
-Any change done on the cluster side will not be part of the restoration and will need to be reapplied. This changes
-include:
+Any change done on the cluster side are not part of the restoration and they need to be reapplied. These changes include:
 
 * Agent upgrades
-* Rtfctl managed secure properties
-* Ingress resources on rtf namespace
+* RTFCTL managed secure properties
+* Ingress resources on Runtime Fabric namespace
 * ConfigMap settings
 
 == Create a Backup

--- a/modules/ROOT/pages/manage-secure-properties.adoc
+++ b/modules/ROOT/pages/manage-secure-properties.adoc
@@ -9,7 +9,7 @@ These properties are accessible in unencrypted form by Mule applications deploye
 Runtime Fabric protected properties always take precedence over application-level properties.
 
 [NOTE]
-This form of secure properties usage is discouraged in favour of the Runtime Manager managed ones.
+Using secure properties outside of Runtime Manager is discouraged in favor of those managed by Runtime Manager.
 
 == Install rtfctl 
 
@@ -59,11 +59,13 @@ sudo ./rtfctl delete secure-property <my_key> -n <namespace>
 * *<my_key>*: The key used in the Mule application to reference the secure property.
 * *<namespace>*: The namespace in which the secure property applies.
 
-== Restoration of Rtfctl Managed Secure Properties
+== Restore RTFCTL Managed Secure Properties
 
-Rtfctl managed secure properties are directly configured in the cluster, these are not sent nor stored in the control plane.
-Because of this, these secure-properties are not taken into account in the backup and restore process thus they need to be
-reapplied after restoration. For more information of how backup and restore works see xref:manage-backup-restore.adoc[this page].
+`rtfctl` managed secure properties are directly configured in the cluster and are neither sent nor stored in the control plane.
+
+Due to this behavior, these secure properties are not included in the backup and restore process, so they need to be reapplied after restoration. 
+
+For details, refer to xref:manage-backup-restore.adoc[].
 
 == See Also
 

--- a/modules/ROOT/pages/manage-secure-properties.adoc
+++ b/modules/ROOT/pages/manage-secure-properties.adoc
@@ -3,9 +3,13 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Secure application properties are added in the Runtime Fabric cluster locally, stored securely, and scoped per environment. These properties are accessible in unencrypted form by Mule applications deployed in the scoped environment as custom properties.
+Secure application properties are added in the Runtime Fabric cluster locally, stored securely, and scoped per environment.
+These properties are accessible in unencrypted form by Mule applications deployed in the scoped environment as custom properties.
 
 Runtime Fabric protected properties always take precedence over application-level properties.
+
+[NOTE]
+This form of secure properties usage is discouraged in favour of the Runtime Manager managed ones.
 
 == Install rtfctl 
 
@@ -54,6 +58,12 @@ sudo ./rtfctl delete secure-property <my_key> -n <namespace>
 +
 * *<my_key>*: The key used in the Mule application to reference the secure property.
 * *<namespace>*: The namespace in which the secure property applies.
+
+== Restoration of Rtfctl Managed Secure Properties
+
+Rtfctl managed secure properties are directly configured in the cluster, these are not sent nor stored in the control plane.
+Because of this, these secure-properties are not taken into account in the backup and restore process thus they need to be
+reapplied after restoration. For more information of how backup and restore works see xref:manage-backup-restore.adoc[this page].
 
 == See Also
 


### PR DESCRIPTION
**Gus Issue:**

[W-17030250
](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000023kmnrYAA/view)

The gus issue talks about rtfctl managed secure properties not being part of the backup bundle thus not being applied on restoration. This is intended behavior, so we are making emphasis on this in the documentation.

Also backup&restore docs is updated with changes about the new behavior expected for control plane synchronized restorations.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
