### PR TITLE
W-14777135-rtf-cluster-role-update-kt

### DIFF
--- a/modules/ROOT/pages/install-openshift.adoc
+++ b/modules/ROOT/pages/install-openshift.adoc
@@ -248,6 +248,41 @@ subjects:
 ----
 
 [start=6]
+. Create the `rtf-cluster-version-reader` ClusterRole and ClusterRoleBinding to allow the Runtime Fabric agent to access OpenShift cluster version information. This is required when using authorized namespaces on OpenShift. Apply this configuration:
++
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rtf-cluster-version-reader
+rules:
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+  - list
+----
++
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rtf-cluster-version-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rtf-cluster-version-reader
+subjects:
+- kind: ServiceAccount
+  name: rtf-agent
+  namespace: <rtf_namespace>
+----
+
+[start=7]
 . In your cluster, create a ConfigMap file named `authorized-namespaces` and list any additional namespaces. Note that the additional namespace mapping keys must be unique since they use the standard K8s resource (ConfigMap). There is no specific requirements on the format of the key name provided they are unique.
 +
 [source,copy]


### PR DESCRIPTION
…nShift authorized namespaces

Add documentation for creating rtf-cluster-version-reader ClusterRole and ClusterRoleBinding required when using authorized namespaces on OpenShift. This allows the Runtime Fabric agent to access OpenShift cluster version information (clusterversions from config.openshift.io API group).

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
