### PR TITLE
W-20616706-rtf-update-security-property-kt

### DIFF
--- a/modules/ROOT/pages/manage-secure-properties.adoc
+++ b/modules/ROOT/pages/manage-secure-properties.adoc
@@ -24,7 +24,7 @@ rtfctl apply secure-property --key <key> --value <value> --app-namespace <app_na
 * *<key>*: The key for the secure property used in the Mule application to reference the value.
 * *<value>*: The value for the secure property to store.
 * *<app_namespace>*: The Anypoint environment to scope this secure property to. Only applications deployed to this environment have access to this secure property.
-** For xref:create-custom-namespace.adoc[customized namespaces], use the actual namespace name (not the environment ID or default namespace name).
+** For xref:create-custom-namespace.adoc[customized namespaces], use the actual namespace name.
 * *<rtf_namespace>*:System namespace scope, defaults to `rtf`.
 
 [NOTE]

--- a/modules/ROOT/pages/manage-secure-properties.adoc
+++ b/modules/ROOT/pages/manage-secure-properties.adoc
@@ -24,7 +24,6 @@ rtfctl apply secure-property --key <key> --value <value> --app-namespace <app_na
 * *<key>*: The key for the secure property used in the Mule application to reference the value.
 * *<value>*: The value for the secure property to store.
 * *<app_namespace>*: The Anypoint environment to scope this secure property to. Only applications deployed to this environment have access to this secure property.
-** For default namespaces, use the environment ID.
 ** For xref:create-custom-namespace.adoc[customized namespaces], use the actual namespace name (not the environment ID or default namespace name).
 * *<rtf_namespace>*:System namespace scope, defaults to `rtf`.
 

--- a/modules/ROOT/pages/manage-secure-properties.adoc
+++ b/modules/ROOT/pages/manage-secure-properties.adoc
@@ -23,7 +23,7 @@ rtfctl apply secure-property --key <key> --value <value> --app-namespace <app_na
 +
 * *<key>*: The key for the secure property used in the Mule application to reference the value.
 * *<value>*: The value for the secure property to store.
-* *<app_namespace>*: The Anypoint environment to scope this secure property to. Only applications deployed to this environment have access to this secure property.
+* *<app_namespace>*: The actual namespace to scope this secure property to. Only applications deployed to this environment have access to this secure property.
 ** For xref:create-custom-namespace.adoc[customized namespaces], use the actual namespace name.
 * *<rtf_namespace>*:System namespace scope, defaults to `rtf`.
 

--- a/modules/ROOT/pages/manage-secure-properties.adoc
+++ b/modules/ROOT/pages/manage-secure-properties.adoc
@@ -23,7 +23,7 @@ rtfctl apply secure-property --key <key> --value <value> --app-namespace <app_na
 +
 * *<key>*: The key for the secure property used in the Mule application to reference the value.
 * *<value>*: The value for the secure property to store.
-* *<app_namespace>*: The actual namespace to scope this secure property to. Only applications deployed to this environment have access to this secure property.
+* *<app_namespace>*: The actual namespace to scope this secure property to. Only applications deployed to this namespace have access to this secure property.
 ** For xref:create-custom-namespace.adoc[customized namespaces], use the actual namespace name.
 * *<rtf_namespace>*:System namespace scope, defaults to `rtf`.
 

--- a/modules/ROOT/pages/manage-secure-properties.adoc
+++ b/modules/ROOT/pages/manage-secure-properties.adoc
@@ -24,7 +24,19 @@ rtfctl apply secure-property --key <key> --value <value> --app-namespace <app_na
 * *<key>*: The key for the secure property used in the Mule application to reference the value.
 * *<value>*: The value for the secure property to store.
 * *<app_namespace>*: The Anypoint environment to scope this secure property to. Only applications deployed to this environment have access to this secure property.
+** For default namespaces, use the environment ID.
+** For xref:create-custom-namespace.adoc[customized namespaces], use the actual namespace name (not the environment ID or default namespace name).
 * *<rtf_namespace>*:System namespace scope, defaults to `rtf`.
+
+[NOTE]
+====
+When applying secure properties to applications deployed in customized namespaces, you must specify the actual namespace name in the `--app-namespace` parameter, not the environment ID or the default namespace name. For example, if you created a customized namespace named `my-custom-namespace`, use that name in the command:
++
+[source,copy]
+----
+rtfctl apply secure-property --key test --value test --app-namespace my-custom-namespace --namespace rtf
+----
+====
 
 == View Secure Properties
 


### PR DESCRIPTION
…secure properties

- Updated manage-secure-properties.adoc to clarify that --app-namespace parameter must use the actual namespace name for customized namespaces, not the environment ID or default namespace name
- Added NOTE section with example showing correct usage for customized namespaces
- Clarified distinction between default namespaces (use environment ID) and customized namespaces (use actual namespace name)

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
