### PR TITLE
W-20998601-rtf-k8s-permissions-kt

### DIFF
--- a/modules/ROOT/pages/rtfctl-permissions.adoc
+++ b/modules/ROOT/pages/rtfctl-permissions.adoc
@@ -36,7 +36,7 @@ The following table lists the permissions that you configure using Kubernetes (K
                                     |batch      |cronjobs       | get, list, watch
                                     |networking.k8s.io      |ingresses       | get, list, watch
                                     |rbac.authorization.k8s.io      |clusterrolebindings, clusterroles, rolebindings, roles       | get, list, watch
-                                    |rtf.mulesoft.com      |persistencegateways       | get, list, watch
+                                    |rtf.mulesoft.com      |persistencegateways, kubernetestemplates, httproutetemplates, muleapplications       | get, list, watch
                                     |scheduling.k8s.io      |priorityclasses       | get
 .10+|`restore`      .3+|rtf           | apps     |daemonsets | create, get, patch, update
                                     | batch    |cronjobs | create, get, patch, update


### PR DESCRIPTION
…rces

Add kubernetestemplates, httproutetemplates, and muleapplications to rtf.mulesoft.com API group permissions for rtfctl backup command. Without these, rtfctl backup fails with latest rtfctl version.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
