### PR TITLE
W-21303975-rtf-compatibility-kt

### DIFF
--- a/modules/ROOT/pages/customize-kubernetes-crd.adoc
+++ b/modules/ROOT/pages/customize-kubernetes-crd.adoc
@@ -253,13 +253,11 @@ pod:
        ENABLE_READINESS_PROBE_ON_HTTP_GET: "true"
 ----
 
-=== Upgrade to Runtime Fabric 3.0.1 or later
+This setting defaults to `false`. When you enable it on Runtime Fabric 3.0.1 or later, use Mule runtime patches from November 7, 2025 and later for your applications. The compatible patch versions are listed in the xref:release-notes::runtime-fabric/runtime-fabric-runtimes-release-notes.adoc#november-7-2025[November 7, 2025] section of the Runtime Fabric runtimes release notes. Applications on older patches may fail to become ready or restart correctly when this feature is enabled.
 
-When you upgrade to Runtime Fabric 3.0.1 or later, applications that run on Mule runtime patch versions older than those listed from xref:release-notes::runtime-fabric/runtime-fabric-runtimes-release-notes.adoc#november-7-2025[November 7, 2025] may fail to become ready or restart correctly. Use Mule runtime patches from November 7, 2025 and later for your applications when upgrading to Runtime Fabric 3.0.1 or later.
+If you want to enable the HTTP GET readiness probe but your applications run on Mule runtime patches older than November 7, 2025, either upgrade those applications to a compatible patch or keep the feature disabled until you can upgrade. To keep it disabled, apply a Kubernetes template that sets `ENABLE_READINESS_PROBE_ON_HTTP_GET` to `"false"`:
 
-If you can't upgrade Mule runtime immediately, apply a Kubernetes template that sets `ENABLE_READINESS_PROBE_ON_HTTP_GET` to `"false"`. This reverts to the previous probe behavior so that applications on older runtime patches can pass health checks until you upgrade them.
-
-. Create or update a Kubernetes template with this content. Set the `namespace` to your Runtime Fabric installation namespace (`rtf`).
+. Create or update a Kubernetes template with this content. Set the `namespace` to your Runtime Fabric installation namespace (typically `rtf`).
 +
 [source,yaml]
 ----

--- a/modules/ROOT/pages/customize-kubernetes-crd.adoc
+++ b/modules/ROOT/pages/customize-kubernetes-crd.adoc
@@ -255,24 +255,8 @@ pod:
 
 This setting defaults to `false`. When you enable it on Runtime Fabric 3.0.1 or later, use Mule runtime engine patches from November 7, 2025 and later for your applications. The compatible patch versions are listed in the xref:release-notes::runtime-fabric/runtime-fabric-runtimes-release-notes.adoc#november-7-2025[November 7, 2025] section of the Runtime Fabric runtimes release notes. Applications on older patches may fail to become ready or restart correctly when this feature is enabled.
 
-If you want to enable the HTTP GET readiness probe but your applications run on Mule runtime engine patches older than November 7, 2025, either upgrade those applications to a compatible patch or keep the feature disabled until you can upgrade. To keep it disabled, apply a Kubernetes template that sets `ENABLE_READINESS_PROBE_ON_HTTP_GET` to `"false"`:
+If you want to enable the HTTP GET readiness probe but your applications run on Mule runtime engine patches older than November 7, 2025, either upgrade those applications to a compatible patch or keep the feature disabled until you can upgrade.
 
-. Create or update a Kubernetes template with this content. Set the `namespace` to your Runtime Fabric installation namespace (typically `rtf`).
-+
-[source,yaml]
-----
-apiVersion: "rtf.mulesoft.com/v1"
-kind: KubernetesTemplate
-metadata:
-  name: mule-application
-  namespace: rtf
-spec:
-  pod:
-    env:
-      ENABLE_READINESS_PROBE_ON_HTTP_GET: "false"
-----
-. Apply the template to your cluster.
-. Restart the affected applications.
 
 == See Also
 

--- a/modules/ROOT/pages/customize-kubernetes-crd.adoc
+++ b/modules/ROOT/pages/customize-kubernetes-crd.adoc
@@ -253,7 +253,7 @@ pod:
        ENABLE_READINESS_PROBE_ON_HTTP_GET: "true"
 ----
 
-This setting defaults to `false`. When you enable it on Runtime Fabric 3.0.1 or later, use Mule runtime engine patches from November 7, 2025 and later for your applications. The compatible patch versions are listed in the xref:release-notes::runtime-fabric/runtime-fabric-runtimes-release-notes.adoc#november-7-2025[November 7, 2025] section of the Runtime Fabric runtimes release notes. Applications on older patches may fail to become ready or restart correctly when this feature is enabled.
+This setting defaults to `false`. When you enable it on Runtime Fabric 3.0.1 or later, use Mule runtime engine patches from November 7, 2025 and later for your applications. For compatible patch versions, see the xref:release-notes::runtime-fabric/runtime-fabric-runtimes-release-notes.adoc#november-7-2025[November 7, 2025] section of the Runtime Fabric runtimes release notes. Applications on older patches may fail to become ready or restart correctly when this feature is enabled.
 
 If you want to enable the HTTP GET readiness probe but your applications run on Mule runtime engine patches older than November 7, 2025, either upgrade those applications to a compatible patch or keep the feature disabled until you can upgrade.
 

--- a/modules/ROOT/pages/customize-kubernetes-crd.adoc
+++ b/modules/ROOT/pages/customize-kubernetes-crd.adoc
@@ -253,6 +253,29 @@ pod:
        ENABLE_READINESS_PROBE_ON_HTTP_GET: "true"
 ----
 
+=== Upgrade to Runtime Fabric 3.0.1 or later
+
+When you upgrade to Runtime Fabric 3.0.1 or later, applications that run on Mule runtime patch versions older than those listed from xref:release-notes::runtime-fabric/runtime-fabric-runtimes-release-notes.adoc#november-7-2025[November 7, 2025] may fail to become ready or restart correctly. Use Mule runtime patches from November 7, 2025 and later for your applications when upgrading to Runtime Fabric 3.0.1 or later.
+
+If you can't upgrade Mule runtime immediately, apply a Kubernetes template that sets `ENABLE_READINESS_PROBE_ON_HTTP_GET` to `"false"`. This reverts to the previous probe behavior so that applications on older runtime patches can pass health checks until you upgrade them.
+
+. Create or update a Kubernetes template with this content. Set the `namespace` to your Runtime Fabric installation namespace (`rtf`).
++
+[source,yaml]
+----
+apiVersion: "rtf.mulesoft.com/v1"
+kind: KubernetesTemplate
+metadata:
+  name: mule-application
+  namespace: rtf
+spec:
+  pod:
+    env:
+      ENABLE_READINESS_PROBE_ON_HTTP_GET: "false"
+----
+. Apply the template to your cluster.
+. Restart the affected applications.
+
 == See Also
 
 * xref:configure-kubernetes.adoc[Configuring Kubernetes for Runtime Fabric]

--- a/modules/ROOT/pages/customize-kubernetes-crd.adoc
+++ b/modules/ROOT/pages/customize-kubernetes-crd.adoc
@@ -253,9 +253,9 @@ pod:
        ENABLE_READINESS_PROBE_ON_HTTP_GET: "true"
 ----
 
-This setting defaults to `false`. When you enable it on Runtime Fabric 3.0.1 or later, use Mule runtime patches from November 7, 2025 and later for your applications. The compatible patch versions are listed in the xref:release-notes::runtime-fabric/runtime-fabric-runtimes-release-notes.adoc#november-7-2025[November 7, 2025] section of the Runtime Fabric runtimes release notes. Applications on older patches may fail to become ready or restart correctly when this feature is enabled.
+This setting defaults to `false`. When you enable it on Runtime Fabric 3.0.1 or later, use Mule runtime engine patches from November 7, 2025 and later for your applications. The compatible patch versions are listed in the xref:release-notes::runtime-fabric/runtime-fabric-runtimes-release-notes.adoc#november-7-2025[November 7, 2025] section of the Runtime Fabric runtimes release notes. Applications on older patches may fail to become ready or restart correctly when this feature is enabled.
 
-If you want to enable the HTTP GET readiness probe but your applications run on Mule runtime patches older than November 7, 2025, either upgrade those applications to a compatible patch or keep the feature disabled until you can upgrade. To keep it disabled, apply a Kubernetes template that sets `ENABLE_READINESS_PROBE_ON_HTTP_GET` to `"false"`:
+If you want to enable the HTTP GET readiness probe but your applications run on Mule runtime engine patches older than November 7, 2025, either upgrade those applications to a compatible patch or keep the feature disabled until you can upgrade. To keep it disabled, apply a Kubernetes template that sets `ENABLE_READINESS_PROBE_ON_HTTP_GET` to `"false"`:
 
 . Create or update a Kubernetes template with this content. Set the `namespace` to your Runtime Fabric installation namespace (typically `rtf`).
 +

--- a/modules/ROOT/pages/customize-kubernetes-crd.adoc
+++ b/modules/ROOT/pages/customize-kubernetes-crd.adoc
@@ -255,7 +255,7 @@ pod:
 
 This setting defaults to `false`. When you enable it on Runtime Fabric 3.0.1 or later, use Mule runtime engine patches from November 7, 2025 and later for your applications. For compatible patch versions, see the xref:release-notes::runtime-fabric/runtime-fabric-runtimes-release-notes.adoc#november-7-2025[November 7, 2025] section of the Runtime Fabric runtimes release notes. Applications on older patches may fail to become ready or restart correctly when this feature is enabled.
 
-If you want to enable the HTTP GET readiness probe but your applications run on Mule runtime engine patches older than November 7, 2025, either upgrade those applications to a compatible patch or keep the feature disabled until you can upgrade.
+To enable the HTTP GET readiness probe for applications running on Mule runtime engine patches older than November 7, 2025, either upgrade those applications to a compatible patch or keep the feature disabled until you can upgrade.
 
 
 == See Also


### PR DESCRIPTION
- Add subsection under Enable Readiness Probe on HTTP GET explaining that applications on older Mule runtime patches may fail when upgrading to RTF 3.0.1 or later
- State minimum Mule runtime patches (November 7, 2025 and later) with xref to release notes
- Document workaround: apply Kubernetes template with ENABLE_READINESS_PROBE_ON_HTTP_GET: false for apps that cannot upgrade runtime immediately (W-21303975)

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
