### PR TITLE
W-21359725: Clarify restart permission requirements

### DIFF
--- a/modules/ROOT/pages/restart-applications.adoc
+++ b/modules/ROOT/pages/restart-applications.adoc
@@ -14,7 +14,7 @@ The restart feature is available for Mule applications deployed to Runtime Fabri
 
 == Before You Begin
 
-Before restarting a Mule application, ensure that you have one of these permissions:
+Before restarting a Mule application, ensure that you have both of these permissions:
 
 * *Restart Applications*
 * *Create Applications*


### PR DESCRIPTION
Update the prerequisite wording to state that both required permissions are needed before restarting a Mule application.

Made-with: Cursor

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
