### PR TITLE
W-21764764-rtf-uppdate-schedulers-2.7-kt

### DIFF
--- a/modules/ROOT/pages/manage-schedules.adoc
+++ b/modules/ROOT/pages/manage-schedules.adoc
@@ -46,7 +46,6 @@ Use the *Schedules* tab or the Runtime Fabric API to manage Runtime Fabric sched
 ** If the value is available before deployment and depends on deployment properties, an estimation of the value appears.
 ** If the value is a placeholder (such as `${cronExpression}`) that is provided at the time of deployment, the exact value of the placeholder does not appear in the user interface.
 ** Runtime Fabric uses a default value of `60000`.
-* If you make changes to schedulers, you should reupload the application to Exchange to ensure the expected scheduler behavior occurs.
 
 == Before You Begin
 


### PR DESCRIPTION
Remove the bullet advising users to reupload the application to Exchange after making scheduler changes. This statement caused customer confusion and was already removed from the CloudHub 2 equivalent page (W-18117891).

Made-with: Cursor

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
