### PR TITLE
W-22062047-rtf-update-schedules-redeploy-kt

### DIFF
--- a/modules/ROOT/pages/manage-schedules.adoc
+++ b/modules/ROOT/pages/manage-schedules.adoc
@@ -28,7 +28,7 @@ When designing the schedule, consider the following:
 * The Runtime Fabric scheduler reads the job configuration every time it runs.
 +
 When you update the scheduler configuration, the change takes effect the next time the scheduler runs.
-* Changing the schedule redeploys your application.
+* Updating the schedule in Runtime Manager or through the Runtime Fabric API—for example, the interval, cron expression, or enabled state—applies the new configuration without redeploying the application.
 * If a scheduled job is not triggered because the application is not running,
 Runtime Fabric triggers the job as soon as the app restarts.
 * Schedules are based in the scheduler's defined timezone.


### PR DESCRIPTION
Schedule changes in Runtime Manager or via the Runtime Fabric API (interval, cron, enabled state) apply without redeploying the app. The previous bullet incorrectly stated that changing the schedule redeploys the application. Changing fixed frequency versus cron type still requires update and redeploy, as documented in the existing IMPORTANT block.


# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
