### PR TITLE
W-21093225-rtf-openshift-properties-secret-updates-kt

### DIFF
--- a/modules/ROOT/pages/configure-local-registry.adoc
+++ b/modules/ROOT/pages/configure-local-registry.adoc
@@ -230,7 +230,10 @@ kubectl create secret docker-registry rtf-pull-secret --namespace <rtf-namespace
 ----
 
 [start=6]
-. Follow the *Helm* path instructions to download the `values.yml` file so that you can modify its values. For the private registry configuration, update `rtfRegistry` with your local docker server, and update the `pullSecretName` parameter. . 
+. Follow the *Helm* path instructions to download the `values.yml` file so that you can modify its values. For the private registry configuration, update `rtfRegistry` with your local docker server, and update the `pullSecretName` parameter.
++
+[IMPORTANT]
+You must configure the `rtfRegistry` and `pullSecretName` values before activating the cluster for the first time. These properties are written to the `generated-properties` secret only during the initial activation and are not updated if changed afterward. Refer to the xref:install-helm.adoc#values-yml-reference[values.yml Reference] for details.
 . Continue with the *Helm* path instructions and install Runtime Fabric in your Kubernetes cluster.
 
 --

--- a/modules/ROOT/pages/install-helm.adoc
+++ b/modules/ROOT/pages/install-helm.adoc
@@ -277,6 +277,11 @@ These required values are created and added to `values.yml` when you create the 
 |`muleLicense` |Mule license for applications |`<mule_license_key>`. Must be Base64 encoded.
 |===
 
+[IMPORTANT]
+--
+The `rtfRegistry`, `pullSecretName`, `provider`, and `repositoryNamespace` properties are written to the `generated-properties` secret only during the initial Runtime Fabric activation (first agent install). If you modify any of these values after activation, the changes are not reflected in the `generated-properties` secret. To avoid image pull errors or incorrect provider configurations, ensure that these values are set correctly before you activate the cluster for the first time.
+--
+
 === Optional Parameters
 
 Set these optional parameters in `values.yml` as needed before installing Runtime Fabric.


### PR DESCRIPTION
Certain Helm values (rtfRegistry, pullSecretName, provider, repositoryNamespace) are written to the generated-properties secret only during the first agent install. Changes made post-activation are not reflected, which can cause image pull errors or incorrect provider configurations. Added IMPORTANT admonitions to install-helm.adoc and configure-local-registry.adoc so users set these values correctly before first activation.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
