### PR TITLE
W-22390920: Rename 'control plane' to 'Cloud' in network configuratio…

### DIFF
--- a/modules/ROOT/pages/install-self-managed-network-configuration.adoc
+++ b/modules/ROOT/pages/install-self-managed-network-configuration.adoc
@@ -36,57 +36,57 @@ The Persistent Gateway requires a Postgres-compliant database to store persisten
 
 To function correctly, Runtime Fabric requires the following hostname endpoint configurations. Give access to these endpoints in your infrastructure to avoid any installation or deployment issues.
 
-== US and EU Control Planes
+=== US Cloud and EU Cloud
 
 [%header,cols="4*a"]
 |===
 | Port | Protocol | Hostnames | Description
 | 443 | AMQP over WebSockets a| 
-* US control plane: `transport-layer.prod.cloudhub.io`
-* EU control plane: `transport-layer.prod-eu.msap.io` | Runtime Fabric message broker for interaction with the control plane.
+* US Cloud: `transport-layer.prod.cloudhub.io`
+* EU Cloud: `transport-layer.prod-eu.msap.io` | Runtime Fabric message broker for interaction with the control plane.
 | 443 (v1.8.50 and later)| TCP (Lumberjack) a| 
-* US control plane: +
+* US Cloud: +
 `dias-ingestor-router.us-east-1.prod.cloudhub.io` +
 `us1.ingest.mulesoft.com` +
 
-* EU control plane: +
+* EU Cloud: +
 `dias-ingestor-router.eu-central-1.prod-eu.msap.io` +
 `eu1.ingest.mulesoft.com` +
 
  | xref:use-anypoint-monitoring.adoc#enable-anypoint-monitoring[Anypoint Monitoring] agent for Runtime Fabric.
 | 5044 (legacy) |TCP (Lumberjack) a| 
-* US control plane: `dias-ingestor-nginx.prod.cloudhub.io`
-* EU control plane: `dias-ingestor-nginx.prod-eu.msap.io` | xref:use-anypoint-monitoring.adoc#enable-anypoint-monitoring[Anypoint Monitoring] agent for Runtime Fabric.
+* US Cloud: `dias-ingestor-nginx.prod.cloudhub.io`
+* EU Cloud: `dias-ingestor-nginx.prod-eu.msap.io` | xref:use-anypoint-monitoring.adoc#enable-anypoint-monitoring[Anypoint Monitoring] agent for Runtime Fabric.
 
 *As of Runtime Fabric version 1.8.50, this port is not strictly required. It will be deprecated in the future.* 
 
 | 443 | HTTPS | `anypoint.mulesoft.com` | Anypoint Platform for pulling assets.
 | 443 | HTTPS a| 
-* US control plane: `worker-cloud-helm-prod.s3.amazonaws.com`
-* EU control plane: `worker-cloud-helm-prod-eu-rt.s3.amazonaws.com`, `worker-cloud-helm-prod-eu-rt.s3.eu-central-1.amazonaws.com` | Runtime Fabric version repository. The Runtime Fabric installation uses software from this repository during installation and upgrades.
+* US Cloud: `worker-cloud-helm-prod.s3.amazonaws.com`
+* EU Cloud: `worker-cloud-helm-prod-eu-rt.s3.amazonaws.com`, `worker-cloud-helm-prod-eu-rt.s3.eu-central-1.amazonaws.com` | Runtime Fabric version repository. The Runtime Fabric installation uses software from this repository during installation and upgrades.
 | 443 | HTTPS a|
-* US control plane: `exchange2-asset-manager-kprod.s3.amazonaws.com`
-* EU control plane: `exchange2-asset-manager-kprod-eu.s3.amazonaws.com`, `exchange2-asset-manager-kprod-eu.s3.eu-central-1.amazonaws.com` |Anypoint Exchange for application assets.
+* US Cloud: `exchange2-asset-manager-kprod.s3.amazonaws.com`
+* EU Cloud: `exchange2-asset-manager-kprod-eu.s3.amazonaws.com`, `exchange2-asset-manager-kprod-eu.s3.eu-central-1.amazonaws.com` |Anypoint Exchange for application assets.
 | 443 | HTTPS a|
-* US control plane: `exchange-files.anypoint.mulesoft.com` 
-* EU control plane: `exchange-files.eu1.anypoint.mulesoft.com` | Anypoint Exchange for application files.
+* US Cloud: `exchange-files.anypoint.mulesoft.com` 
+* EU Cloud: `exchange-files.eu1.anypoint.mulesoft.com` | Anypoint Exchange for application files.
 | 443 | HTTPS a| 
-* US control plane: `rtf-runtime-registry.kprod.msap.io`
-* EU control plane: `rtf-runtime-registry.kprod-eu.msap.io` | Runtime Fabric Docker repository.
+* US Cloud: `rtf-runtime-registry.kprod.msap.io`
+* EU Cloud: `rtf-runtime-registry.kprod-eu.msap.io` | Runtime Fabric Docker repository.
 | 443 | HTTPS a| 
-* US control plane: `prod-us-east-1-starport-layer-bucket.s3.amazonaws.com`, `prod-us-east-1-starport-layer-bucket.s3.us-east-1.amazonaws.com`
-* EU control plane: `prod-eu-central-1-starport-layer-bucket.s3.amazonaws.com`, `prod-eu-central-1-starport-layer-bucket.s3.eu-central-1.amazonaws.com` | Runtime Fabric Docker image delivery.
+* US Cloud: `prod-us-east-1-starport-layer-bucket.s3.amazonaws.com`, `prod-us-east-1-starport-layer-bucket.s3.us-east-1.amazonaws.com`
+* EU Cloud: `prod-eu-central-1-starport-layer-bucket.s3.amazonaws.com`, `prod-eu-central-1-starport-layer-bucket.s3.eu-central-1.amazonaws.com` | Runtime Fabric Docker image delivery.
 | 443 | HTTPS a| 
-* US control plane: `runtime-fabric.s3.amazonaws.com`
-* EU control plane: `runtime-fabric-eu.s3.amazonaws.com` | Runtime Fabric Docker repository.
+* US Cloud: `runtime-fabric.s3.amazonaws.com`
+* EU Cloud: `runtime-fabric-eu.s3.amazonaws.com` | Runtime Fabric Docker repository.
 | 443 | HTTPS a|
-* US control plane: `configuration-resolver.prod.cloudhub.io`
-* EU control plane: `configuration-resolver.prod-eu.msap.io` | Anypoint Configuration Resolver.
+* US Cloud: `configuration-resolver.prod.cloudhub.io`
+* EU Cloud: `configuration-resolver.prod-eu.msap.io` | Anypoint Configuration Resolver.
 |===
 
-=== Canada Control Plane
+=== Canada Cloud
 
-This table lists the required hostname endpoint configurations for the Canada control plane.
+This table lists the required hostname endpoint configurations for the Canada Cloud.
 
 [%header,cols="4*a"]
 |===


### PR DESCRIPTION


Update US/EU/Canada control plane references to use the current 'US Cloud', 'EU Cloud', and 'Canada Cloud' terminology throughout the hostname endpoint configuration tables.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
