### PR TITLE
W-22483844, W-22264115: Add SFCI registry info for Canada and Japan Hyperforce

### DIFF
--- a/modules/ROOT/pages/configure-local-registry.adoc
+++ b/modules/ROOT/pages/configure-local-registry.adoc
@@ -37,7 +37,24 @@ MuleSoft doesn’t provide additional software to synchronize third party depend
 [[synch-runtime]]
 == Synchronize Mule Runtime Dependencies and Images to Your Local Registry
 
-To synchronize in your registry the Mule runtime versions you intend to use for application deployments, refer to the xref:release-notes::runtime-fabric/runtime-fabric-runtimes-release-notes.adoc[Mule runtime patch updates for Runtime Fabric Release Notes]. The location of the image follows this format: `rtf-runtime-registry.kprod.msap.io/mulesoft/`.
+To synchronize in your registry the Mule runtime versions you intend to use for application deployments, refer to the xref:release-notes::runtime-fabric/runtime-fabric-runtimes-release-notes.adoc[Mule runtime patch updates for Runtime Fabric Release Notes]. The location of the image depends on the control plane:
+
+[%header%autowidth.spread]
+|===
+| Control Plane | Image Location Format
+| US Cloud | `rtf-runtime-registry.kprod.msap.io/mulesoft/<image>:<tag>`
+| EU Cloud | `rtf-runtime-registry.kprod-eu.msap.io/mulesoft/<image>:<tag>`
+| Canada Cloud | `rtf-runtime-registry-mulesoft-cp.sfdc-58ktaz.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/<image>:<tag>`
+| Japan Cloud | `rtf-runtime-registry-mulesoft-cp.sfdc-mchho0.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/<image>:<tag>`
+|===
+
+[NOTE]
+====
+For Canada Cloud and Japan Cloud deployments on OpenShift, download the following images from the SFCI registry:
+
+* Mule runtime: `/sfci/mulesoft/ms-docker-image/ms-poseidon-runtime-<version>:<tag>`
+* Anypoint Monitoring sidecar: `/sfci/mulesoft/ms-docker-image/ms-dias-anypoint-monitoring-sidecar-ubi:<version>`
+====
 
 [[synch-rtf]]
 == Synchronize Runtime Fabric Core Software Dependencies and Images to Your Local Registry
@@ -69,8 +86,8 @@ dependencies=$(curl <platform-url>/runtimefabric/api/agentmanifests/<agent-versi
 for i in $dependencies
 do
     echo "Processing $i"
-    docker pull <mulesoft-docker-server>/mulesoft/$i
-    docker tag  <mulesoft-docker-server>/mulesoft/$i <local-docker-server>/mulesoft/$i
+    docker pull <mulesoft-docker-server>/<image-path>/$i
+    docker tag  <mulesoft-docker-server>/<image-path>/$i <local-docker-server>/mulesoft/$i
     docker push <local-docker-server>/mulesoft/$i
 done
 ----
@@ -85,8 +102,8 @@ dependencies=$(curl <platform-url>/runtimefabric/api/agentmanifests/<agent-versi
 for i in $dependencies
 do
     echo "Processing $i"
-    docker pull <mulesoft-docker-server>/mulesoft/$i
-    docker tag  <mulesoft-docker-server>/mulesoft/$i <local-docker-server>/mulesoft/$i
+    docker pull <mulesoft-docker-server>/<image-path>/$i
+    docker tag  <mulesoft-docker-server>/<image-path>/$i <local-docker-server>/mulesoft/$i
     docker push <local-docker-server>/mulesoft/$i
 done
 ----
@@ -99,8 +116,13 @@ done
 | `agent-version` | Runtime Fabric agent release version required for the synchronization.
 | `authorization-token` |  Authorization token required for using connected apps to perform the synchronization. When you use this token, a link redirects to the connected apps page.
 | `mulesoft-docker-server` |  MuleSoft Docker server required for the synchronization. +
-For the US control plane: `rtf-runtime-registry.kprod.msap.io` +
-For the EU control plane: `rtf-runtime-registry.kprod-eu.msap.io`
+For US Cloud: `rtf-runtime-registry.kprod.msap.io` +
+For EU Cloud: `rtf-runtime-registry.kprod-eu.msap.io` +
+For Canada Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-58ktaz.svc.sfdcfc.net` +
+For Japan Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-mchho0.svc.sfdcfc.net`
+| `image-path` | Image namespace path on the registry. +
+For US Cloud and EU Cloud: `mulesoft` +
+For Canada Cloud and Japan Cloud: `sfci/mulesoft/ms-docker-image`
 |===
 
 --
@@ -112,7 +134,7 @@ To synchronize the dependencies images manually, follow these steps:
 
 . Log in to your private container registry and run the following command, replacing `docker-server` where appropriate:
 +
-For the US control plane:
+For the US Cloud:
 +
 [source,copy]
 ---- 
@@ -121,13 +143,31 @@ For the US control plane:
 # docker push <docker-server>/mulesoft/rtf-agent:v1.12.0
 ----
 +
-For the EU control plane:
+For the EU Cloud:
 +
 [source,copy]
 ---- 
 # docker pull rtf-runtime-registry.kprod-eu.msap.io/mulesoft/rtf-agent:v1.12.0 
 # docker tag rtf-runtime-registry.kprod-eu.msap.io/mulesoft/rtf-agent:v1.12.0 <docker-server>/mulesoft/rtf-agent:v1.12.0 
-# docker push <docker-server>:5000/mulesoft/rtf-agent:v1.12.0
+# docker push <docker-server>/mulesoft/rtf-agent:v1.12.0
+----
++
+For the Canada Cloud:
++
+[source,copy]
+---- 
+# docker pull rtf-runtime-registry-mulesoft-cp.sfdc-58ktaz.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/rtf-agent:v1.12.0 
+# docker tag rtf-runtime-registry-mulesoft-cp.sfdc-58ktaz.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/rtf-agent:v1.12.0 <docker-server>/mulesoft/rtf-agent:v1.12.0 
+# docker push <docker-server>/mulesoft/rtf-agent:v1.12.0
+----
++
+For the Japan cont  rol plane:
++
+[source,copy]
+---- 
+# docker pull rtf-runtime-registry-mulesoft-cp.sfdc-mchho0.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/rtf-agent:v1.12.0 
+# docker tag rtf-runtime-registry-mulesoft-cp.sfdc-mchho0.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/rtf-agent:v1.12.0 <docker-server>/mulesoft/rtf-agent:v1.12.0 
+# docker push <docker-server>/mulesoft/rtf-agent:v1.12.0
 ----
 --
 ====

--- a/modules/ROOT/pages/install-helm.adoc
+++ b/modules/ROOT/pages/install-helm.adoc
@@ -75,7 +75,7 @@ Using `rtf` as a namespace applies only in the case of single cluster or single 
 
 After you create the namespace, create a pull secret so you can retrieve the Docker images needed to install and run Runtime Fabric.
 
-The default registry URL is `rtf-runtime-registry.kprod.msap.io`. If you’re using a local registry, specify those values here.
+The registry URL depends on your control plane. Refer to the <<required-parameters,required parameters>> section for the `rtfRegistry` value for your region. If you’re using a local registry, specify those values here.
 
 To create the pull secret, run:
 
@@ -262,8 +262,9 @@ global:
 ----
 
 [NOTE]
-If you are configuring a Runtime Fabric BYOK with an EU control plane, review the changes in xref:runtime-fabric::install-self-managed-network-configuration.adoc#hostname-configuration[Hostname Configuration] for a correct configuration. Specifically, the property `rtfRegistry: rtf-runtime-registry.kprod-eu.msap.io`.
+If you are configuring a Runtime Fabric BYOK with a non-US control plane, review the changes in xref:runtime-fabric::install-self-managed-network-configuration.adoc#hostname-configuration[Hostname Configuration] for a correct configuration. Set the `rtfRegistry` property to the registry URL for your control plane.
 
+[[required-parameters]]
 === Required Parameters
 
 These required values are created and added to `values.yml` when you create the Runtime Fabric in Runtime Manager:
@@ -272,7 +273,11 @@ These required values are created and added to `values.yml` when you create the 
 |===
 |Key |Value |Example
 |`activationData` |Activation data |YW55cG9pbnQubXVsZXNvZnQuY29tOjBmODdmYzYzLTM3MWUtNDU2Yy1iODg5LTU5NTkyNjYyZjUxZQ==
-|`rtfRegistry` |Registry URL  |`rtf-runtime-registry.kprod.msap.io`
+|`rtfRegistry` |Registry URL  a|
+* US: `rtf-runtime-registry.kprod.msap.io`
+* EU: `rtf-runtime-registry.kprod-eu.msap.io`
+* Canada: `rtf-runtime-registry-mulesoft-cp.sfdc-58ktaz.svc.sfdcfc.net`
+* Japan: `rtf-runtime-registry-mulesoft-cp.sfdc-mchho0.svc.sfdcfc.net`
 |`pullSecretName` |Registry secret |`<pull_secret>`
 |`muleLicense` |Mule license for applications |`<mule_license_key>`. Must be Base64 encoded.
 |===

--- a/modules/ROOT/pages/install-multiple-instances-openshift.adoc
+++ b/modules/ROOT/pages/install-multiple-instances-openshift.adoc
@@ -252,10 +252,11 @@ The values for these required parameters are set when you create the Runtime Fab
 |===
 | Key | Value | Example
 | `activationData` | Activation Data | YW55cG9pbnQubXVsZXNvZnQuY29tOjBmODdmYzYzLTM3MWUtNDU2Yy1iODg5LTU5NTkyNjYyZjUxZQ==
-| `rtfRegistry` | Registry URL  | US rtf-runtime-registry.kprod.msap.io
-
-EU
-rtf-runtime-registry.kprod-eu.msap.io
+| `rtfRegistry` | Registry URL  a|
+* US: `rtf-runtime-registry.kprod.msap.io`
+* EU: `rtf-runtime-registry.kprod-eu.msap.io`
+* Canada: `rtf-runtime-registry-mulesoft-cp.sfdc-58ktaz.svc.sfdcfc.net`
+* Japan: `rtf-runtime-registry-mulesoft-cp.sfdc-mchho0.svc.sfdcfc.net`
 | `pullSecretName` | Registry pull secret | rtf-pull-secret
 | `muleLicense` | Mule license for applications | Mule license key (must be Base64-encoded)
 |===

--- a/modules/ROOT/pages/install-multiple-instances.adoc
+++ b/modules/ROOT/pages/install-multiple-instances.adoc
@@ -48,10 +48,11 @@ The values for these required parameters are set when you create the Runtime Fab
 |===
 | Key | Value | Example
 | `activationData` | Activation Data | YW55cG9pbnQubXVsZXNvZnQuY29tOjBmODdmYzYzLTM3MWUtNDU2Yy1iODg5LTU5NTkyNjYyZjUxZQ==
-| `rtfRegistry` | Registry URL  | US rtf-runtime-registry.kprod.msap.io
-
-EU
-rtf-runtime-registry.kprod-eu.msap.io
+| `rtfRegistry` | Registry URL  a|
+* US: `rtf-runtime-registry.kprod.msap.io`
+* EU: `rtf-runtime-registry.kprod-eu.msap.io`
+* Canada: `rtf-runtime-registry-mulesoft-cp.sfdc-58ktaz.svc.sfdcfc.net`
+* Japan: `rtf-runtime-registry-mulesoft-cp.sfdc-mchho0.svc.sfdcfc.net`
 | `pullSecretName` | Registry pull secret | rtf-pull-secret
 | `muleLicense` | Mule license for applications | Mule license key (must be Base64-encoded)
 |===

--- a/modules/ROOT/pages/install-openshift.adoc
+++ b/modules/ROOT/pages/install-openshift.adoc
@@ -64,7 +64,7 @@ oc create ns <rtf-namespace>
 
 After you create the namespace, create a pull secret so you can retrieve the Docker images needed to install and run Runtime Fabric.
 
-The default registry URL is `rtf-runtime-registry.kprod.msap.io`. If you’re using a local registry, specify those values here.
+The registry URL depends on your control plane. Refer to the <<required-parameters,required parameters>> section for the `rtfRegistry` value for your region. If you’re using a local registry, specify those values here.
 
 To create the pull secret, run:
 
@@ -358,6 +358,7 @@ global:
   - /var/log/pods
 --
 
+[[required-parameters]]
 === Required Parameters
 
 The values for these required parameters are set when you create the Runtime Fabric in Runtime Manager. If you’re not using a local registry, use the default values for the registry URL and pull secret.
@@ -366,7 +367,11 @@ The values for these required parameters are set when you create the Runtime Fab
 |===
 |Key |Value |Example
 |`activationData` |Activation data |YW55cG9pbnQubXVsZXNvZnQuY29tOjBmODdmYzYzLTM3MWUtNDU2Yy1iODg5LTU5NTkyNjYyZjUxZQ==
-|`rtfRegistry` |Registry URL  |`rtf-runtime-registry.kprod.msap.io`
+|`rtfRegistry` |Registry URL  a|
+* US: `rtf-runtime-registry.kprod.msap.io`
+* EU: `rtf-runtime-registry.kprod-eu.msap.io`
+* Canada: `rtf-runtime-registry-mulesoft-cp.sfdc-58ktaz.svc.sfdcfc.net`
+* Japan: `rtf-runtime-registry-mulesoft-cp.sfdc-mchho0.svc.sfdcfc.net`
 |`pullSecretName` |Registry secret |`<pull_secret>`
 |`muleLicense` |Mule license for applications |`<mule_license_key>`. Must be Base64 encoded.
 |===

--- a/modules/ROOT/pages/install-self-managed-network-configuration.adoc
+++ b/modules/ROOT/pages/install-self-managed-network-configuration.adoc
@@ -100,6 +100,16 @@ This table lists the required hostname endpoint configurations for the Canada Cl
 | 443 | HTTPS | `prod-us-east-1-starport-layer-bucket.s3.us-east-1.amazonaws.com` | Runtime Fabric Docker image delivery.
 |===
 
+=== Japan Cloud
+
+This table lists the required hostname endpoint configurations for the Japan Cloud.
+
+[%header,cols="4*a"]
+|===
+| Port | Protocol | Hostnames | Description
+| 443 | HTTPS | `rtf-runtime-registry-mulesoft-cp.sfdc-mchho0.svc.sfdcfc.net` | Runtime Fabric Docker and Helm chart repository. All container images (Mule runtime, monitoring sidecars, and Runtime Fabric agent) are pulled from this registry.
+|===
+
 == Verify Outbound Connectivity
 
 Every Anypoint Runtime Fabric cluster requires connectivity with Anypoint control plane, and any interference with connectivity can limit functionality, resulting in application deployment failures or degraded status in Anypoint Runtime Manager.


### PR DESCRIPTION
## Summary

- Add Canada and Japan Hyperforce SFCI container image registry URLs (`rtf-runtime-registry-mulesoft-cp.sfdc-58ktaz.svc.sfdcfc.net` and `rtf-runtime-registry-mulesoft-cp.sfdc-mchho0.svc.sfdcfc.net`) across all install and local registry documentation.
- Update `configure-local-registry.adoc`: add image location format table by control plane, add OpenShift-specific note for Hyperforce images (`ms-poseidon-runtime` and `ms-dias-anypoint-monitoring-sidecar-ubi`), add CA/JP manual sync examples, and update automated sync scripts with a configurable `image-path` parameter to support the SFCI namespace (`sfci/mulesoft/ms-docker-image`).
- Add Japan Cloud section to `install-self-managed-network-configuration.adoc` with the SFCI registry endpoint.
- Update `rtfRegistry` parameter examples in `install-helm.adoc`, `install-openshift.adoc`, `install-multiple-instances.adoc`, and `install-multiple-instances-openshift.adoc` to list all four control planes (US, EU, Canada, Japan).

## Test plan
- [ ] Verify AsciiDoc renders correctly for all modified pages (tables, notes, code blocks).
- [ ] Confirm the Canada and Japan registry hostnames and SFCI image paths are accurate with ENG.
- [ ] Validate that the automated sync script parameters table includes the new `image-path` parameter.


Made with [Cursor](https://cursor.com)