### PR TITLE
W-22402743: Document supported pod.env keys for Anypoint Controller

### DIFF
--- a/modules/ROOT/pages/deploy-mule-app-anypoint-controller.adoc
+++ b/modules/ROOT/pages/deploy-mule-app-anypoint-controller.adoc
@@ -1824,7 +1824,7 @@ spec:
 ----
 ====
 
-[%collapsible]
+[#kubernetes-customization%collapsible]
 .Kubernetes Customization
 ====
 Customize pod, service, and deployment metadata:
@@ -1891,12 +1891,10 @@ spec:
     # Service account
     automountServiceAccountToken: true
     
-    # Environment variables
+    # Environment variables (only specific keys are supported)
     env:
-      - name: ENABLE_CONSOLE_LOG
-        value: "true"
-      - name: TZ
-        value: "America/New_York"
+      ENABLE_CONSOLE_LOG: "true"
+      ENABLE_READINESS_PROBE_ON_HTTP_GET: "true"
     
     # Ephemeral storage
     ephemeralStorageLimit: 4Gi
@@ -1915,8 +1913,20 @@ spec:
       annotations:
         fluxcd.io/automated: "true"
 ----
+
+[IMPORTANT]
+=====
+The `pod.env` field uses `map[string]string` format (for example, `ENABLE_CONSOLE_LOG: "true"`), not a list of `name`/`value` pairs. As with the xref:customize-kubernetes-crd.adoc[KubernetesTemplate] CR, it supports only the keys listed in this list. Any other key (for example, `MY_CUSTOM_VAR`) is ignored.
+
+* `ENABLE_CONSOLE_LOG`: Enables console logging for the application container. Emitted as a container environment variable. For more information, see xref:customize-kubernetes-crd.adoc#enable-console-logging[Enable Console Logging].
+* `ENABLE_READINESS_PROBE_ON_HTTP_GET`: Enables the native Kubernetes HTTP GET probe for readiness. Requires Mule runtime engine patches from November 7, 2025 or later; older patches might fail to become ready. Emitted as a container environment variable. For more information, see xref:customize-kubernetes-crd.adoc#enable-readiness-probe[Enable Readiness Probe on HTTP GET].
+* `DISABLE_PER_APP_SA`: Disables the per-application service account, so the Mule application uses the default namespace service account. Controls deployment-level behavior. For more information, see xref:customize-kubernetes-crd.adoc#disable-service-account[Disable Per Application Service Account].
+
+To pass custom configuration values to your Mule application, use the `properties` or `propertiesFrom` fields instead. For more information, see <<mounting-properties-from-external-sources>>.
+=====
 ====
 
+[[mounting-properties-from-external-sources]]
 === Mounting Properties from External Sources
 
 The `propertiesFrom` field in the Mule application CR `spec` enables you to inject application properties from Kubernetes Secrets and ConfigMaps without hardcoding them in the Custom Resource.


### PR DESCRIPTION
## Summary

Scoped documentation update for the Kubernetes Customization section of the Anypoint Controller page. Clarifies that `pod.env` accepts only a fixed set of supported keys.

- Add the `#kubernetes-customization` anchor to the collapsible block so it can be cross-referenced.
- Convert the `env` example to `map[string]string` format and note that only specific keys are supported.
- Add an IMPORTANT block listing the only supported `pod.env` keys (`ENABLE_CONSOLE_LOG`, `ENABLE_READINESS_PROBE_ON_HTTP_GET`, `DISABLE_PER_APP_SA`) with their effects, plus the `mounting-properties-from-external-sources` anchor referenced from it.

## Test plan

- [ ] Build the docs site and confirm the Kubernetes Customization block renders with the new IMPORTANT note and key list.
- [ ] Confirm the `<<mounting-properties-from-external-sources>>` cross-reference resolves.
- [ ] Confirm the `#kubernetes-customization` anchor resolves.

Made with [Cursor](https://cursor.com)