### PR TITLE
Remove Anypoint from index.adoc title

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,4 +1,4 @@
-= Anypoint Runtime Fabric Overview
+= Runtime Fabric Overview
 
 Anypoint Runtime Fabric enables you to deploy Mule applications and API proxies to a Kubernetes cluster that you create, configure, and manage. 
 


### PR DESCRIPTION
## Summary
- Updated the title from "Anypoint Runtime Fabric Overview" to "Runtime Fabric Overview"

## Test plan
- [ ] Verify title change in index.adoc
- [ ] Build documentation locally to ensure no broken links
- [ ] Confirm title appears correctly on docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)