### PR TITLE
W-23025071: Correct Anypoint Monitoring protocol to HTTPS (not Lumber…

### DIFF
--- a/modules/ROOT/pages/install-self-managed-network-configuration.adoc
+++ b/modules/ROOT/pages/install-self-managed-network-configuration.adoc
@@ -25,7 +25,7 @@ The following table does not include ports and hostnames from Anypoint Platform 
 | 443 | TCP | HTTPS | API consumers | All nodes | Allow inbound API requests to ingress controllers
 | 443 | TCP | AMQP over WebSockets | All nodes | Internet | Anypoint Platform management services
 | 443 | TCP | HTTPS | All nodes | Internet | API Manager policy updates, API Analytics Ingestion, and Resource retrieval (application files, container images).
-| 443 (v1.8.50, or later) | TCP | Lumberjack | All nodes | Internet | Anypoint Monitoring, Anypoint Visualizer
+| 443 (v1.8.50, or later) | TCP | HTTPS | All nodes | Internet | Anypoint Monitoring, Anypoint Visualizer
 |===
 
 == Port Used by the Persistence Gateway
@@ -44,7 +44,7 @@ To function correctly, Runtime Fabric requires the following hostname endpoint c
 | 443 | AMQP over WebSockets a| 
 * US Cloud: `transport-layer.prod.cloudhub.io`
 * EU Cloud: `transport-layer.prod-eu.msap.io` | Runtime Fabric message broker for interaction with the control plane.
-| 443 (v1.8.50 and later)| TCP (Lumberjack) a| 
+| 443 (v1.8.50 and later)| HTTPS a| 
 * US Cloud: +
 `dias-ingestor-router.us-east-1.prod.cloudhub.io` +
 `us1.ingest.mulesoft.com` +

--- a/modules/ROOT/pages/install-self-managed-network-configuration.adoc
+++ b/modules/ROOT/pages/install-self-managed-network-configuration.adoc
@@ -43,27 +43,14 @@ This table lists the required hostname endpoint configurations for the US Cloud.
 [%header,cols="4*a"]
 |===
 | Port | Protocol | Hostnames | Description
-| 443 | AMQP over WebSockets a| 
-* US Cloud: `transport-layer.prod.cloudhub.io`
-* EU Cloud: `transport-layer.prod-eu.msap.io` | Runtime Fabric message broker for interaction with the control plane.
-| 443 (v2.6.22 and later)| HTTPS a|
-* US Cloud: `us1.ingest.mulesoft.com`
-* EU Cloud: `eu1.ingest.mulesoft.com`
+| 443 | AMQP over WebSockets | `transport-layer.prod.cloudhub.io` | Runtime Fabric message broker for interaction with the control plane.
+| 443 (v2.6.22 and later) | HTTPS | `us1.ingest.mulesoft.com` | xref:use-anypoint-monitoring.adoc#enable-anypoint-monitoring[Anypoint Monitoring] agent for Runtime Fabric.
+| 443 (pre-2.6.22, legacy) | TCP (Lumberjack) | `dias-ingestor-router.us-east-1.prod.cloudhub.io` | xref:use-anypoint-monitoring.adoc#enable-anypoint-monitoring[Anypoint Monitoring] agent for Runtime Fabric.
 
- | xref:use-anypoint-monitoring.adoc#enable-anypoint-monitoring[Anypoint Monitoring] agent for Runtime Fabric.
-| 443 (pre-2.6.22, legacy) | TCP (Lumberjack) a|
-* US Cloud: `dias-ingestor-router.us-east-1.prod.cloudhub.io`
-* EU Cloud: `dias-ingestor-router.eu-central-1.prod-eu.msap.io`
+*Required only for RTF versions prior to 2.6.22. After upgrading to RTF 2.6.22 or later and redeploying all applications, this endpoint is no longer used.*
+| 5044 (legacy) | TCP (Lumberjack) | `dias-ingestor-nginx.prod.cloudhub.io` | xref:use-anypoint-monitoring.adoc#enable-anypoint-monitoring[Anypoint Monitoring] agent for Runtime Fabric.
 
- | xref:use-anypoint-monitoring.adoc#enable-anypoint-monitoring[Anypoint Monitoring] agent for Runtime Fabric.
-
-*Required only for RTF versions prior to 2.6.22. After upgrading to RTF 2.6.22 or later and redeploying all applications, these endpoints are no longer used.*
-| 5044 (legacy) |TCP (Lumberjack) a| 
-* US Cloud: `dias-ingestor-nginx.prod.cloudhub.io`
-* EU Cloud: `dias-ingestor-nginx.prod-eu.msap.io` | xref:use-anypoint-monitoring.adoc#enable-anypoint-monitoring[Anypoint Monitoring] agent for Runtime Fabric.
-
-*As of Runtime Fabric version 1.8.50, this port is not strictly required. It will be deprecated in the future.* 
-
+*As of Runtime Fabric version 1.8.50, this port is not strictly required. It will be deprecated in the future.*
 | 443 | HTTPS | `anypoint.mulesoft.com` | Anypoint Platform for pulling assets.
 | 443 | HTTPS | `worker-cloud-helm-prod.s3.amazonaws.com` | Runtime Fabric version repository. The Runtime Fabric installation uses software from this repository during installation and upgrades.
 | 443 | HTTPS | `exchange2-asset-manager-kprod.s3.amazonaws.com` | Anypoint Exchange for application assets.
@@ -82,11 +69,13 @@ This table lists the required hostname endpoint configurations for the EU Cloud.
 |===
 | Port | Protocol | Hostnames | Description
 | 443 | AMQP over WebSockets | `transport-layer.prod-eu.msap.io` | Runtime Fabric message broker for interaction with the control plane.
-| 443 (v1.8.50 and later) | TCP (Lumberjack) | `dias-ingestor-router.eu-central-1.prod-eu.msap.io` +
-`eu1.ingest.mulesoft.com` | xref:use-anypoint-monitoring.adoc#enable-anypoint-monitoring[Anypoint Monitoring] agent for Runtime Fabric.
+| 443 (v2.6.22 and later) | HTTPS | `eu1.ingest.mulesoft.com` | xref:use-anypoint-monitoring.adoc#enable-anypoint-monitoring[Anypoint Monitoring] agent for Runtime Fabric.
+| 443 (pre-2.6.22, legacy) | TCP (Lumberjack) | `dias-ingestor-router.eu-central-1.prod-eu.msap.io` | xref:use-anypoint-monitoring.adoc#enable-anypoint-monitoring[Anypoint Monitoring] agent for Runtime Fabric.
+
+*Required only for RTF versions prior to 2.6.22. After upgrading to RTF 2.6.22 or later and redeploying all applications, this endpoint is no longer used.*
 | 5044 (legacy) | TCP (Lumberjack) | `dias-ingestor-nginx.prod-eu.msap.io` | xref:use-anypoint-monitoring.adoc#enable-anypoint-monitoring[Anypoint Monitoring] agent for Runtime Fabric.
 
-*As of Runtime Fabric version 1.8.50, this port isn't strictly required. It will be deprecated in the future.*
+*As of Runtime Fabric version 1.8.50, this port is not strictly required. It will be deprecated in the future.*
 
 | 443 | HTTPS | `anypoint.mulesoft.com` | Anypoint Platform for pulling assets.
 | 443 | HTTPS | `worker-cloud-helm-prod-eu-rt.s3.amazonaws.com`, `worker-cloud-helm-prod-eu-rt.s3.eu-central-1.amazonaws.com` | Runtime Fabric version repository. The Runtime Fabric installation uses software from this repository during installation and upgrades.

--- a/modules/ROOT/pages/install-self-managed-network-configuration.adoc
+++ b/modules/ROOT/pages/install-self-managed-network-configuration.adoc
@@ -47,10 +47,10 @@ This table lists the required hostname endpoint configurations for the US Cloud.
 | 443 (v2.6.22 and later) | HTTPS | `us1.ingest.mulesoft.com` | xref:use-anypoint-monitoring.adoc#enable-anypoint-monitoring[Anypoint Monitoring] agent for Runtime Fabric.
 | 443 (pre-2.6.22, legacy) | TCP (Lumberjack) | `dias-ingestor-router.us-east-1.prod.cloudhub.io` | xref:use-anypoint-monitoring.adoc#enable-anypoint-monitoring[Anypoint Monitoring] agent for Runtime Fabric.
 
-*Required only for RTF versions prior to 2.6.22. After upgrading to RTF 2.6.22 or later and redeploying all applications, this endpoint is no longer used.*
+*Required only for Runtime Fabric versions earlier than 2.6.22. After upgrading to Runtime Fabric 2.6.22 or later and redeploying all applications, this endpoint is no longer used.*
 | 5044 (legacy) | TCP (Lumberjack) | `dias-ingestor-nginx.prod.cloudhub.io` | xref:use-anypoint-monitoring.adoc#enable-anypoint-monitoring[Anypoint Monitoring] agent for Runtime Fabric.
 
-*As of Runtime Fabric version 1.8.50, this port is not strictly required. It will be deprecated in the future.*
+*Starting with Runtime Fabric version 1.8.50, this port is not required. It will be deprecated in the future.*
 | 443 | HTTPS | `anypoint.mulesoft.com` | Anypoint Platform for pulling assets.
 | 443 | HTTPS | `worker-cloud-helm-prod.s3.amazonaws.com` | Runtime Fabric version repository. The Runtime Fabric installation uses software from this repository during installation and upgrades.
 | 443 | HTTPS | `exchange2-asset-manager-kprod.s3.amazonaws.com` | Anypoint Exchange for application assets.
@@ -72,10 +72,10 @@ This table lists the required hostname endpoint configurations for the EU Cloud.
 | 443 (v2.6.22 and later) | HTTPS | `eu1.ingest.mulesoft.com` | xref:use-anypoint-monitoring.adoc#enable-anypoint-monitoring[Anypoint Monitoring] agent for Runtime Fabric.
 | 443 (pre-2.6.22, legacy) | TCP (Lumberjack) | `dias-ingestor-router.eu-central-1.prod-eu.msap.io` | xref:use-anypoint-monitoring.adoc#enable-anypoint-monitoring[Anypoint Monitoring] agent for Runtime Fabric.
 
-*Required only for RTF versions prior to 2.6.22. After upgrading to RTF 2.6.22 or later and redeploying all applications, this endpoint is no longer used.*
+*Required only for Runtime Fabric versions earlier than 2.6.22. After upgrading to Runtime Fabric 2.6.22 or later and redeploying all applications, this endpoint is no longer used.*
 | 5044 (legacy) | TCP (Lumberjack) | `dias-ingestor-nginx.prod-eu.msap.io` | xref:use-anypoint-monitoring.adoc#enable-anypoint-monitoring[Anypoint Monitoring] agent for Runtime Fabric.
 
-*As of Runtime Fabric version 1.8.50, this port is not strictly required. It will be deprecated in the future.*
+*Starting with Runtime Fabric version 1.8.50, this port is not required. It will be deprecated in the future.*
 
 | 443 | HTTPS | `anypoint.mulesoft.com` | Anypoint Platform for pulling assets.
 | 443 | HTTPS | `worker-cloud-helm-prod-eu-rt.s3.amazonaws.com`, `worker-cloud-helm-prod-eu-rt.s3.eu-central-1.amazonaws.com` | Runtime Fabric version repository. The Runtime Fabric installation uses software from this repository during installation and upgrades.

--- a/modules/ROOT/pages/install-self-managed-network-configuration.adoc
+++ b/modules/ROOT/pages/install-self-managed-network-configuration.adoc
@@ -44,16 +44,18 @@ To function correctly, Runtime Fabric requires the following hostname endpoint c
 | 443 | AMQP over WebSockets a| 
 * US Cloud: `transport-layer.prod.cloudhub.io`
 * EU Cloud: `transport-layer.prod-eu.msap.io` | Runtime Fabric message broker for interaction with the control plane.
-| 443 (v1.8.50 and later)| HTTPS a| 
-* US Cloud: +
-`dias-ingestor-router.us-east-1.prod.cloudhub.io` +
-`us1.ingest.mulesoft.com` +
-
-* EU Cloud: +
-`dias-ingestor-router.eu-central-1.prod-eu.msap.io` +
-`eu1.ingest.mulesoft.com` +
+| 443 (v2.6.22 and later)| HTTPS a|
+* US Cloud: `us1.ingest.mulesoft.com`
+* EU Cloud: `eu1.ingest.mulesoft.com`
 
  | xref:use-anypoint-monitoring.adoc#enable-anypoint-monitoring[Anypoint Monitoring] agent for Runtime Fabric.
+| 443 (pre-2.6.22, legacy) | TCP (Lumberjack) a|
+* US Cloud: `dias-ingestor-router.us-east-1.prod.cloudhub.io`
+* EU Cloud: `dias-ingestor-router.eu-central-1.prod-eu.msap.io`
+
+ | xref:use-anypoint-monitoring.adoc#enable-anypoint-monitoring[Anypoint Monitoring] agent for Runtime Fabric.
+
+*Required only for RTF versions prior to 2.6.22. After upgrading to RTF 2.6.22 or later and redeploying all applications, these endpoints are no longer used.*
 | 5044 (legacy) |TCP (Lumberjack) a| 
 * US Cloud: `dias-ingestor-nginx.prod.cloudhub.io`
 * EU Cloud: `dias-ingestor-nginx.prod-eu.msap.io` | xref:use-anypoint-monitoring.adoc#enable-anypoint-monitoring[Anypoint Monitoring] agent for Runtime Fabric.

--- a/modules/ROOT/pages/use-anypoint-monitoring.adoc
+++ b/modules/ROOT/pages/use-anypoint-monitoring.adoc
@@ -10,28 +10,24 @@ Metrics collection is enabled by default for all plans. Log and trace collection
 
 === Verify Network Connectivity
 
-For metrics, logs, and traces to reach Anypoint Monitoring, each node in Runtime Fabric must be able to send outbound HTTPS traffic on TCP port 443 to these domains:
+For metrics, logs, and traces to reach Anypoint Monitoring, each node in Runtime Fabric must be able to send outbound traffic to the control plane ingestion endpoint for your region.
 
-* US Cloud: +
-`dias-ingestor-router.us-east-1.prod.cloudhub.io` +
-`us1.ingest.mulesoft.com`
+For Runtime Fabric agent version 2.6.22 and later, the monitoring sidecar sends HTTPS traffic on TCP port 443 to these domains:
 
-* EU Cloud: +
-`dias-ingestor-router.eu-central-1.prod-eu.msap.io` +
-`eu1.ingest.mulesoft.com`
-
-* Canada Cloud (port 8443, OTEL): +
-`ingest.ca1.platform.mulesoft.com`
-
-* Japan Cloud (port 8443, OTEL): +
-`ingest.jp1.platform.mulesoft.com`
-
-* India Cloud (port 8443, OTEL): +
-`ingest.in1.platform.mulesoft.com`
+* US Cloud: `us1.ingest.mulesoft.com`
+* EU Cloud: `eu1.ingest.mulesoft.com`
+* Canada Cloud (port 8443, OTEL): `ingest.ca1.platform.mulesoft.com`
+* Japan Cloud (port 8443, OTEL): `ingest.jp1.platform.mulesoft.com`
+* India Cloud (port 8443, OTEL): `ingest.in1.platform.mulesoft.com`
 
 [NOTE]
 ====
-If you are using Runtime Fabric older than version 1.8.50, use port 5044 instead of port 443 and these domains:
+For Runtime Fabric versions earlier than 2.6.22, the agent sends TCP (Lumberjack) traffic on port 443 to a different domain. After you upgrade to 2.6.22 or later and redeploy all applications, this domain is no longer used:
+
+* US Cloud: `dias-ingestor-router.us-east-1.prod.cloudhub.io`
+* EU Cloud: `dias-ingestor-router.eu-central-1.prod-eu.msap.io`
+
+For Runtime Fabric versions earlier than 1.8.50, use port 5044 (TCP Lumberjack) and these domains:
 
 * US Cloud: `dias-ingestor-nginx.prod.cloudhub.io`
 * EU Cloud: `dias-ingestor-nginx.prod-eu.msap.io`

--- a/modules/ROOT/pages/use-anypoint-monitoring.adoc
+++ b/modules/ROOT/pages/use-anypoint-monitoring.adoc
@@ -22,7 +22,7 @@ For Runtime Fabric agent version 2.6.22 and later, the monitoring sidecar sends 
 
 [NOTE]
 ====
-For Runtime Fabric versions earlier than 2.6.22, the agent sends TCP (Lumberjack) traffic on port 443 to a different domain. After you upgrade to 2.6.22 or later and redeploy all applications, this domain is no longer used:
+For Runtime Fabric versions earlier than 2.6.22, the agent sends TCP (Lumberjack) traffic on port 443 to a different domain. After you upgrade to 2.6.22 or later and redeploy all applications, these domains are no longer used:
 
 * US Cloud: `dias-ingestor-router.us-east-1.prod.cloudhub.io`
 * EU Cloud: `dias-ingestor-router.eu-central-1.prod-eu.msap.io`

--- a/modules/ROOT/pages/use-anypoint-monitoring.adoc
+++ b/modules/ROOT/pages/use-anypoint-monitoring.adoc
@@ -10,7 +10,7 @@ Metrics collection is enabled by default for all plans. Log and trace collection
 
 === Verify Network Connectivity
 
-For metrics, logs, and traces to reach Anypoint Monitoring, each node in Runtime Fabric must be able to send outbound TCP traffic on port 443 to these domains:
+For metrics, logs, and traces to reach Anypoint Monitoring, each node in Runtime Fabric must be able to send outbound HTTPS traffic on TCP port 443 to these domains:
 
 * US control plane: +
 `dias-ingestor-router.us-east-1.prod.cloudhub.io` +


### PR DESCRIPTION
…jack)

Update the v1.8.50+ Anypoint Monitoring ingestion entries on port 443 from TCP/Lumberjack (L4) to HTTPS (L7) to match the current ingestion endpoints. The legacy port 5044 path remains labeled Lumberjack.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released
