### PR TITLE
W-21966506: Update rtfd container resources page for OpenShift upgrades

### DIFF
--- a/modules/ROOT/pages/upgrade-index.adoc
+++ b/modules/ROOT/pages/upgrade-index.adoc
@@ -8,8 +8,8 @@ Use the `rtfctl` command line tool to upgrade Runtime Fabric.
 Use Helm package manager to upgrade Runtime Fabric.
 * xref:upgrade-openshift.adoc[Upgrading Runtime Fabric as a Kubernetes (K8s) Operator] +
 Use the Red Hat OpenShift console to upgrade Runtime Fabric on Red Hat OpenShift.
-* xref:upgrade-pre-requisites.adoc[Upgrading Runtime Fabric on Red Hat OpenShift] +
-Update the `rtfd` container values.
+* xref:upgrade-pre-requisites.adoc[Update rtfd Container Resources When Upgrading Runtime Fabric on Red Hat OpenShift] +
+Manually update `rtfd` container resource allocations when upgrading from version 2.6.52 or earlier to version 2.7.0 or later.
 
 == See Also
 

--- a/modules/ROOT/pages/upgrade-index.adoc
+++ b/modules/ROOT/pages/upgrade-index.adoc
@@ -8,7 +8,8 @@ Use the `rtfctl` command line tool to upgrade Runtime Fabric.
 Use Helm package manager to upgrade Runtime Fabric.
 * xref:upgrade-openshift.adoc[Upgrading Runtime Fabric as a Kubernetes (K8s) Operator] +
 Use the Red Hat OpenShift console to upgrade Runtime Fabric on Red Hat OpenShift.
-* xref:upgrade-pre-requisites.adoc[Update rtfd Container Resources When Upgrading Runtime Fabric on Red Hat OpenShift] +
+* xref:upgrade-pre-requisites.adoc[Update rtfd Container Resources When Upgrading Runtime Fabric on Red Hat OpenShift]  
++
 Manually update `rtfd` container resource allocations when upgrading from version 2.6.52 or earlier to version 2.7.0 or later.
 
 == See Also

--- a/modules/ROOT/pages/upgrade-pre-requisites.adoc
+++ b/modules/ROOT/pages/upgrade-pre-requisites.adoc
@@ -11,7 +11,7 @@ To update `rtfd` container resources:
 +
 image::runtime-fabric-yaml.png[Runtime Fabric instance .yaml file.]
 +
-. In the `.yaml` file, go to `spec:` > `agent:` > `rtfd:`, and update the resource allocations to the following recommended values:
+. In the `.yaml` file, go to `spec:` > `agent:` > `rtfd:`, and update the resource allocations to these recommended values:
 +
 [source,yaml]
 ----

--- a/modules/ROOT/pages/upgrade-pre-requisites.adoc
+++ b/modules/ROOT/pages/upgrade-pre-requisites.adoc
@@ -1,19 +1,35 @@
-= Upgrading Runtime Fabric on Red Hat OpenShift
+= Update rtfd Container Resources When Upgrading Runtime Fabric on Red Hat OpenShift
 
-For all OpenShift upgrades from versions 2.6.52 and earlier to versions 2.7.0 and later, you must manually increase the `rtfd` container resources to the desired values. See xref:runtime-fabric::rtf-scale.adoc[Scalability Benchmarks] for guidance on `rtfd` container resource values.
+Before upgrading Runtime Fabric on Red Hat OpenShift from version 2.6.52 or earlier to version 2.7.0 or later, you must manually set the `rtfd` container resource allocations to the recommended values. This step is required because the upgrade process doesn't automatically apply resource changes to the `rtfd` container.
 
-To update `rtfd` container resources: 
+For additional guidance on sizing, see xref:runtime-fabric::rtf-scale.adoc[Scalability Benchmarks].
+
+To update `rtfd` container resources:
 
 . In the Red Hat OpenShift console, navigate to *Operators* > *Installed Operators*.
 . Select the *Runtime Fabric* operator and open the Runtime Fabric instance `.yaml` file.
 +
 image::runtime-fabric-yaml.png[Runtime Fabric instance .yaml file.]
 +
-. In the `.yaml` file, go to  `spec:` > `agent:` > `rtfd:`, and update the resource allocations to recommended values.
+. In the `.yaml` file, go to `spec:` > `agent:` > `rtfd:`, and update the resource allocations to the following recommended values:
 +
-image::rtfd-change-values.png[Update rtfd resource allocations to recommended values.]
+[source,yaml]
+----
+rtfd:
+  resources:
+    limits:
+      cpu: 200m
+      memory: 300Mi
+    requests:
+      cpu: 150m
+      memory: 200Mi
+----
 +
 . Click *Save*.
 
 [NOTE]
-For Helm-based upgrades, if the Helm-based installations had previously overridden `rtfd` container resources in the `values.yaml` file, then you must manually increase the allocations as per scalability guidelines, as Helm-based upgrades respect pre-release manual overrides.
+For Helm-based upgrades, if the Helm-based installations had previously overridden `rtfd` container resources in the `values.yaml` file, you must manually increase the allocations as per scalability guidelines, because Helm-based upgrades respect pre-release manual overrides.
+
+== See Also
+
+* xref:upgrade-index.adoc[]

--- a/modules/ROOT/pages/upgrade-pre-requisites.adoc
+++ b/modules/ROOT/pages/upgrade-pre-requisites.adoc
@@ -28,7 +28,7 @@ rtfd:
 . Click *Save*.
 
 [NOTE]
-For Helm-based upgrades, if the Helm-based installations had previously overridden `rtfd` container resources in the `values.yaml` file, you must manually increase the allocations as per scalability guidelines, because Helm-based upgrades respect pre-release manual overrides.
+During a Helm-based upgrade, if you previously overrode `rtfd` container resources in the `values.yaml` file, manually increase the allocations according to the scalability guidelines. This manual step is required because upgrades respect pre-release overrides.
 
 == See Also
 


### PR DESCRIPTION
## Summary

- Rewrites `upgrade-pre-requisites.adoc` with an accurate title and clearer introduction that explains when and why the manual `rtfd` resource update is required
- Replaces the unreadable screenshot (`rtfd-change-values.png`) with an inline YAML code block showing the exact recommended resource values, improving accessibility
- Moves the Scalability Benchmarks xref from a blocker in the intro to a supplemental reference
- Updates the `upgrade-index.adoc` entry with the new title and a descriptive sentence

## Test plan

- [ ] Verify page renders correctly in the docs preview
- [ ] Confirm YAML code block displays the correct values
- [ ] Confirm xref to `upgrade-index.adoc` resolves correctly from the See Also section
- [ ] Confirm `upgrade-index.adoc` entry links and description are accurate