### PR TITLE
W-18978608: Document Helm ownership metadata for HPA on Runtime Fabric

### DIFF
--- a/modules/ROOT/pages/configure-horizontal-autoscaling.adoc
+++ b/modules/ROOT/pages/configure-horizontal-autoscaling.adoc
@@ -100,12 +100,19 @@ MuleSoft owns and applies the https://kubernetes.io/docs/concepts/workloads/auto
 
 The following example shows the CPU-based HPA policy used for Mule apps deployed on Runtime Fabric instances. Note that you can choose `minReplicas` and `maxReplicas` values from the Runtime Manager user interface. 
 
+Runtime Fabric deploys your Mule apps with Helm. The `HorizontalPodAutoscaler` resource therefore includes the Helm ownership label and annotations shown in the following example. These values allow Helm to recognize and manage the resource as part of the application release. If you manually create or modify the HPA, you must keep these labels and annotations, where `<app-name>` is the name of your application and `<app-namespace>` is the environment namespace ID:
+
 ----
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: my-app
   namespace: app-namespace
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    meta.helm.sh/release-name: <app-name>
+    meta.helm.sh/release-namespace: <app-namespace>
 spec:
   behavior:
     scaleDown:
@@ -248,3 +255,52 @@ The `grep` command filters the output of `kubectl get events` for lines that con
 5m5s   Normal SuccessfulRescale   HorizontalPodAutoscaler   New size: 8; reason: cpu resource utilization (percentage of request) above target
 4m50s  Normal SuccessfulRescale   HorizontalPodAutoscaler   New size: 10; reason:
 ----
+
+== Troubleshooting
+
+=== Deployment Fails with `invalid ownership metadata` Error
+
+When you deploy a Mule app with autoscaling enabled, the deployment can fail and the app shows a *Not running* status in Runtime Manager with an error similar to the following:
+
+[source,text,linenums]
+----
+1 or more replicas in unexpected state: [Runtime Fabric] UNKNOWN: running helm install:
+failed to upgrade: failed to upgrade chart runtime-fabric-public/rtf-mule-chart:<version>:
+Unable to continue with update: HorizontalPodAutoscaler "<app-name>" in namespace
+"<app-namespace>" exists and cannot be imported into the current release: invalid ownership
+metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to
+"Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to
+"<app-name>"; annotation validation error: missing key "meta.helm.sh/release-namespace": must
+be set to "<app-namespace>"
+----
+
+This error occurs when a `HorizontalPodAutoscaler` (or another Kubernetes resource, such as a `Service` or `ServiceAccount`) with the same name already exists in the namespace but is not owned by Helm because it is missing the required Helm ownership label and annotations. Helm refuses to take ownership of a resource it did not create, so the deployment fails. This commonly happens when:
+
+* An HPA was created manually or by a tool other than Runtime Fabric.
+* A previous deployment left orphaned resources on the cluster after the application was removed from Runtime Manager, leaving Runtime Manager and the cluster out of sync.
+
+To resolve the error, use one of the following options:
+
+* *Add the Helm ownership metadata to the existing resource.* Patch the resource so that Helm can adopt it, where `<app-name>` is the application name and `<app-namespace>` is the environment namespace ID:
++
+[source,console,linenums]
+----
+kubectl label horizontalpodautoscaler <app-name> -n <app-namespace> \
+  app.kubernetes.io/managed-by=Helm --overwrite
+
+kubectl annotate horizontalpodautoscaler <app-name> -n <app-namespace> \
+  meta.helm.sh/release-name=<app-name> \
+  meta.helm.sh/release-namespace=<app-namespace> --overwrite
+----
++
+* *Delete the conflicting resource.* If the resource is left over from a previous deployment, delete it so that Runtime Fabric can recreate it during the next deployment. Verify that the resource is not in use before deleting it:
++
+[source,console,linenums]
+----
+kubectl delete horizontalpodautoscaler <app-name> -n <app-namespace>
+----
++
+[NOTE]
+If the error references a different resource type, such as `Service` or `ServiceAccount`, apply the same option to that resource. When the cluster is out of sync, more than one orphaned resource might be missing the Helm ownership metadata.
+
+After you resolve the conflict, redeploy the application from Runtime Manager.

--- a/modules/ROOT/pages/configure-horizontal-autoscaling.adoc
+++ b/modules/ROOT/pages/configure-horizontal-autoscaling.adoc
@@ -20,7 +20,7 @@ Refer to your managed vendors documentation on how to install or enable metrics 
 
 == Recommendations for Cluster Autoscaling
 
-The following recommendations are for your infrastructure team to configure cluster autoscaling
+These recommendations are for your infrastructure team to configure cluster autoscaling
 
 === Configure Node Groups
 
@@ -47,7 +47,7 @@ topology.kubernetes.io/zone
 Start the cluster autoscaler with flag `--balance-similar-node-groups=true` and exclude the custom labels previously mentioned in the node groups section with the flag `--balancing-ignore-label`.
 These flags ensure that the cluster autoscaler balances the number of nodes across availability zones. 
 
-For reference on managed EKS cluster, the following node labels are different across node groups:
+For reference on managed EKS cluster, these node labels are different across node groups:
 
 ----
 k8s.amazonaws.com/eniConfigCustom
@@ -98,9 +98,9 @@ Customizing topology spread with `whenUnsatisfiable: DoNotSchedule`, without the
 
 MuleSoft owns and applies the https://kubernetes.io/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/[autoscaling^] policy for your Mule application deployments.
 
-The following example shows the CPU-based HPA policy used for Mule apps deployed on Runtime Fabric instances. Note that you can choose `minReplicas` and `maxReplicas` values from the Runtime Manager user interface. 
+This example shows the CPU-based HPA policy used for Mule apps deployed on Runtime Fabric instances. Note that you can choose `minReplicas` and `maxReplicas` values from the Runtime Manager user interface. 
 
-Runtime Fabric deploys your Mule apps with Helm. The `HorizontalPodAutoscaler` resource therefore includes the Helm ownership label and annotations shown in the following example. These values allow Helm to recognize and manage the resource as part of the application release. If you manually create or modify the HPA, you must keep these labels and annotations, where `<app-name>` is the name of your application and `<app-namespace>` is the environment namespace ID:
+Runtime Fabric deploys your Mule apps with Helm. The `HorizontalPodAutoscaler` resource therefore includes the Helm ownership label and annotations shown in this example. These values allow Helm to recognize and manage the resource as part of the application release. If you manually create or modify the HPA, you must keep these labels and annotations, where `<app-name>` is the name of your application and `<app-namespace>` is the environment namespace ID:
 
 ----
 apiVersion: autoscaling/v2
@@ -172,7 +172,7 @@ If pod average use is greater than 70% in a period (periods for scale-up are set
 
 == Performance Considerations and Limitations
 
-For a successful horizontal autoscaling of your Mule apps, review the following performance considerations:
+For a successful horizontal autoscaling of your Mule apps, review these performance considerations:
 
 * In Runtime Fabric, the policy in use was benchmarked for Mule apps with CPU Reserved: 0.45vCpu and Limit: 0.55vCpu, which corresponds to these settings:
 +
@@ -194,7 +194,7 @@ For a successful horizontal autoscaling of your Mule apps, review the following 
 ** APIKit Routing
 ** API Gateways with policies
 
-* Non-reentrant apps that do not have built in parallel processing such as batch jobs, scheduler apps without re-entrancy and duplicate scheduling across apps and low throughput, high latency apps with large requests may not be a good fit with CPU based HPA.
+* Non-reentrant apps that don't have built in parallel processing such as batch jobs, scheduler apps without re-entrancy and duplicate scheduling across apps and low throughput, high latency apps with large requests may not be a good fit with CPU based HPA.
 
 * Scale up and scale down performance can vary based on the replica size and the application type.
 
@@ -230,14 +230,14 @@ You can also track when autoscaling events occurred through *Audit logs* in Acce
 
 image::rtf-hpa-rtm-2.png[Runtime Manager UI with Audit logs and Scaling status]
 
-The following is an example log payload:
+This is an example log payload:
 
 [source,console,linenums]
 ----
 {"properties":{"organizationId":"my-orgID-abc","environmentId":"my-envID-xyz","response":{"message":{"message":"Application id:my-appID-123 scaled DOWN from 3 to 2 replicas.","logLevel":"INFO","context":{"logger":"Runtime Manager"},"timestamp":1700234556678}},"deploymentId":"my-appID-123","initialRequest":"/organizations/my-orgID-abc/environments/my-envID-xyz/deployments/my-appID-123/specs/my-specID-456"},"subaction":"Scaling"}
 ----
 
-Additionally, you can track the scaled up replicas startup and the number of replicas of your Mule apps by running the following `kubectl` command in your terminal:
+Additionally, you can track the scaled up replicas startup and the number of replicas of your Mule apps by running this `kubectl` command in your terminal:
 
 [source,console,linenums]
 ----
@@ -246,7 +246,7 @@ kubectl get events | grep HorizontalPodAutoscaler
 
 Use the `kubectl get events` command in Kubernetes to retrieve events that occurred within the cluster. The command provides information about various activities and changes happening in the cluster, such as pod creations, deletions, and other important events.
 
-The `grep` command filters the output of `kubectl get events` for lines that contain the string `HorizontalPodAutoscaler`. The following example shows the command output that includes events related to a `HorizontalPodAutoscaler` with information about successful rescaling operations triggered by the HPA:
+The `grep` command filters the output of `kubectl get events` for lines that contain the string `HorizontalPodAutoscaler`. This example shows the command output that includes events related to a `HorizontalPodAutoscaler` with information about successful rescaling operations triggered by the HPA:
 
 [source,console,linenums]
 ----
@@ -260,7 +260,7 @@ The `grep` command filters the output of `kubectl get events` for lines that con
 
 === Deployment Fails with `invalid ownership metadata` Error
 
-When you deploy a Mule app with autoscaling enabled, the deployment can fail and the app shows a *Not running* status in Runtime Manager with an error similar to the following:
+When you deploy a Mule app with autoscaling enabled, the deployment can fail and the app shows a *Not running* status in Runtime Manager with an error similar to this:
 
 [source,text,linenums]
 ----
@@ -279,9 +279,10 @@ This error occurs when a `HorizontalPodAutoscaler` (or another Kubernetes resour
 * An HPA was created manually or by a tool other than Runtime Fabric.
 * A previous deployment left orphaned resources on the cluster after the application was removed from Runtime Manager, leaving Runtime Manager and the cluster out of sync.
 
-To resolve the error, use one of the following options:
+To resolve the error, use one of these options:
 
-* *Add the Helm ownership metadata to the existing resource.* Patch the resource so that Helm can adopt it, where `<app-name>` is the application name and `<app-namespace>` is the environment namespace ID:
+* Add the Helm ownership metadata to the existing resource. +
+Patch the resource so that Helm can adopt it, where `<app-name>` is the application name and `<app-namespace>` is the environment namespace ID:
 +
 [source,console,linenums]
 ----
@@ -293,7 +294,8 @@ kubectl annotate horizontalpodautoscaler <app-name> -n <app-namespace> \
   meta.helm.sh/release-namespace=<app-namespace> --overwrite
 ----
 +
-* *Delete the conflicting resource.* If the resource is left over from a previous deployment, delete it so that Runtime Fabric can recreate it during the next deployment. Verify that the resource is not in use before deleting it:
+* Delete the conflicting resource. +
+If the resource is left over from a previous deployment, delete it so that Runtime Fabric can recreate it during the next deployment. Verify that the resource is not in use before deleting it:
 +
 [source,console,linenums]
 ----


### PR DESCRIPTION
## Summary

Addresses GUS [W-18978608](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002HdXpdYAF/view) (RTF: Update Configure HPA docs).

Users hit a deployment failure in Runtime Manager when configuring Horizontal Pod Autoscaling (HPA), with the error `HorizontalPodAutoscaler "<app>" ... exists and cannot be imported into the current release: invalid ownership metadata`. The root cause is a pre-existing HPA (or other Kubernetes resource) that is not owned by Helm because it is missing the `app.kubernetes.io/managed-by: Helm` label and the `meta.helm.sh/release-name` / `meta.helm.sh/release-namespace` annotations.

Changes to `configure-horizontal-autoscaling.adoc`:

- Add the required Helm ownership label and annotations to the CPU-based HPA policy example, with an explanation of why they are needed and what to keep when manually creating/modifying the HPA.
- Add a **Troubleshooting** section documenting the `invalid ownership metadata` error, its cause, and two resolution paths (patch the resource with Helm metadata, or delete the orphaned resource and redeploy).

This pattern is corroborated by multiple Slack reports in `#support-rtf`, `#rtf-hybrid-dev`, `#ms-prodeng-asks`, and `#ms-support-swarm-si` (related GUS item: W-14044908).

## Test plan

- [ ] Verify the page renders correctly in the docs preview
- [ ] Confirm the YAML example and `kubectl` commands are accurate
- [ ] SME/ENG review of the troubleshooting guidance

Made with [Cursor](https://cursor.com)