### PR TITLE
W-23159982: Add Runtime Fabric Mule diagnostics agent page

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -69,6 +69,7 @@
 * xref:manage-monitor-applications.adoc[Monitoring Mule Apps]
   ** xref:use-log4j-appender.adoc[Exporting Telemetry Externally]
   ** xref:use-anypoint-monitoring.adoc[Using Anypoint Monitoring with Runtime Fabric]
+  ** xref:view-app-diagnostics.adoc[Generating Apps Diagnostics and Analyzing with Einstein]
   ** xref:migrate-log-forwarding.adoc[Migrate Log Forwarding Before Upgrading Runtime Fabric]
 * xref:hardening-apps-deployed-runtime-fabric.adoc[Hardening Mule Apps ]
  ** xref:protect-app-properties.adoc[Protecting Mule App Property Values]

--- a/modules/ROOT/pages/_partials/diagnostics-agent.adoc
+++ b/modules/ROOT/pages/_partials/diagnostics-agent.adoc
@@ -1,0 +1,24 @@
+
+// tag::prerequisites[]
+* Connect your MuleSoft organization to a Salesforce account. 
+* Enable Agentforce for your organization. See xref:access-management::enabling-agentforce.adoc#enable-einstein-anypoint[Enable Agentforce for Your Anypoint Platform Organization]. 
+* Enable Einstein entitlement for your Anypoint Platform organization. See https://help.salesforce.com/s/articleView?id=platform.mulesoft_enable_einstein_anypoint_platform.htm&type=5[Enable Einstein Entitlement and Routing in Anypoint Platform].
+* Verify that you have either the Mule Developer Generative AI User or Organization Administrator role.
+* Update your Mule runtime to 4.6.23 LTS, 4.9.10 LTS, 4.10 Edge, or later. 
+* Verify that your Mule application is running.
+// end::prerequisites[]
+
+
+// tag::diafFile[]
+The DIAF is a structured, standardized plain-text file. It centralizes diagnostic data and organizes it for improved automated and manual analysis. The DIAF captures the state of events, operations, and critical application data. See xref:mule-runtime::mule-troubleshooting-plugin.adoc[Mule Troubleshooting Plugin]. 
+// end::diafFile[]
+
+// tag::considerationsLimitations[]
+The MuleSoft diagnostics agent uses Einstein generative AI. Limits for running analyses apply per application and per organization:
+
+* 10 analyses per application, per hour
+* 50 analyses per organization, per hour
+* 50 analyses per application, per day
+* 200 analyses per organization, per day
+
+// end::considerationsLimitations[]

--- a/modules/ROOT/pages/view-app-diagnostics.adoc
+++ b/modules/ROOT/pages/view-app-diagnostics.adoc
@@ -1,0 +1,50 @@
+= Generating Apps Diagnostics and Analyzing with Einstein
+
+Use the MuleSoft diagnostics agent to troubleshoot your Mule applications deployed to Runtime Fabric. This feature leverages Einstein generative AI to automate diagnostics collection and provide intelligent, actionable insights.
+
+== Before you Begin
+
+Before running the MuleSoft diagnostics agent:
+
+include::partial$diagnostics-agent.adoc[tag=prerequisites]
+
+
+[[run-diagnostics-agent]]
+== Run the MuleSoft Diagnostics Agent
+
+. From Anypoint Platform, select *Runtime Manager* > *Applications*.
+. Select the app name.
+. In the navigation menu, select *Diagnostics*.
+. Select an active replica from the dropdown list.
+. Click the *Analyze & Troubleshoot* dropdown. You have these options:
+** Select *Generate Mule Diagnostics* to generate and download the diagnostics for manual inspection.
+... Click *Download* to download the Mule diagnostics files.
+** Select *Analyze with Einstein* to generate the Mule diagnostics and run the analysis simultaneously. 
+... Click *View Analysis* to open the analysis page.
+
+=== Generate Mule Diagnostics
+If you download the generated Mule diagnostics, you receive a `.tar` archive containing two key assets:
+
+Mule Thread Dumps::
++
+A thread dump is a snapshot of all the threads in a replica that shows the current state of the server.
+
+Diagnostic Information Analysis File (DIAF)::
++
+include::partial$diagnostics-agent.adoc[tag=diafFile]
++
+[NOTE]
+The DIAF doesn’t replace application logs.
+
+=== Analyze with Einstein
+If you select *Analyze with Einstein*, the system generates the Mule diagnostics and runs the Einstein analysis simultaneously. The resulting analysis identifies root causes and recommends actions based on the DIAF file.
+
+== Considerations and Limitations
+
+include::partial$diagnostics-agent.adoc[tag=considerationsLimitations]
+
+Runtime Fabric retains Mule diagnostics for 30 days or up to 150 MB.
+
+== See Also
+* xref:mule-runtime::mule-troubleshooting-plugin.adoc#understanding-diagnostic-information-analysis-file-diaf[Understanding the Diagnostic Information Analysis File (DIAF)]
+* xref:use-anypoint-monitoring.adoc[Using Anypoint Monitoring with Runtime Fabric]

--- a/modules/ROOT/pages/view-app-diagnostics.adoc
+++ b/modules/ROOT/pages/view-app-diagnostics.adoc
@@ -8,6 +8,11 @@ Before running the MuleSoft diagnostics agent:
 
 include::partial$diagnostics-agent.adoc[tag=prerequisites]
 
+For Runtime Fabric, verify that you are running these minimum versions:
+
+* `rtf-agent` <TBD>
+* `rtf-mule-actions` 2.0.7
+
 
 [[run-diagnostics-agent]]
 == Run the MuleSoft Diagnostics Agent


### PR DESCRIPTION
## Summary
- Add a new Runtime Fabric page, `view-app-diagnostics.adoc`, documenting the MuleSoft diagnostics agent and Einstein analysis, adapted from the CloudHub 2.0 `ch2-view-diag.adoc` page (CloudHub 2.0 references replaced with Runtime Fabric).
- Add the `diagnostics-agent.adoc` partial (prerequisites, DIAF description, considerations/limitations) used by the new page.
- Add a nav entry under *Monitoring Mule Apps*.

## Notes
- The page is named `view-app-diagnostics.adoc` since the RTF repo does not use the `ch2-` prefix convention.
- The *See Also* link to the CloudHub-only `ch2-view-logs.adoc` was repointed to `use-anypoint-monitoring.adoc`, the Runtime Fabric monitoring equivalent.
- The "30 days / 150 MB" diagnostics retention figure was a literal CloudHub 2.0 -> Runtime Fabric swap; please confirm these values are accurate for Runtime Fabric.

## Test plan
- [ ] Verify the page renders and the nav entry appears under Monitoring Mule Apps.
- [ ] Verify all xref links resolve.

Made with [Cursor](https://cursor.com)