### PR TITLE
W-20192634: Document global.core.tolerations and global.core.affinity in Helm values reference

### DIFF
--- a/modules/ROOT/pages/install-helm.adoc
+++ b/modules/ROOT/pages/install-helm.adoc
@@ -309,6 +309,8 @@ a|
 |`nodeWatcherEnabled` |Enables or disables node watcher for the cluster | `nodeWatcherEnabled:true` default value `true`
 |`deploymentRateLimitPerSecond` |Sets the deployment rate limit per second | `deploymentRateLimitPerSecond: 1` default value `1`
 |`fipsEnabled` |Enable FIPS for Helm managed Runtime Fabrics. | `fipsEnabled: true` default value `false`
+|`global.core.affinity` |Applies Kubernetes affinity and anti-affinity rules to RTF core service pods. Available from RTF 2.11.0. | See xref:install-helm.adoc#configure-core-software-high-availability-parameters[Configure Core Software High Availability Parameters].
+|`global.core.tolerations` |Applies Kubernetes tolerations to RTF core service pods, allowing them to be scheduled on nodes with matching taints. Available from RTF 2.11.0. | See xref:install-helm.adoc#configure-core-software-high-availability-parameters[Configure Core Software High Availability Parameters].
 |===
 
 === Configure Core Software High Availability Parameters
@@ -395,6 +397,19 @@ global:
                   operator: In
                   values:
                     - amd64
+----
+
+You can use `global.core.tolerations` to apply Kubernetes https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[tolerations^] to Runtime Fabric core service pods. Use this to allow core pods to be scheduled on nodes that have specific taints. For example, to tolerate a node tainted with `dedicated=rtf:NoSchedule`:
+
+[source,yaml]
+----
+global:
+  core:
+    tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "rtf"
+        effect: "NoSchedule"
 ----
 
 [NOTE]

--- a/modules/ROOT/pages/install-helm.adoc
+++ b/modules/ROOT/pages/install-helm.adoc
@@ -309,8 +309,8 @@ a|
 |`nodeWatcherEnabled` |Enables or disables node watcher for the cluster | `nodeWatcherEnabled:true` default value `true`
 |`deploymentRateLimitPerSecond` |Sets the deployment rate limit per second | `deploymentRateLimitPerSecond: 1` default value `1`
 |`fipsEnabled` |Enable FIPS for Helm managed Runtime Fabrics. | `fipsEnabled: true` default value `false`
-|`global.core.affinity` |Applies Kubernetes affinity and anti-affinity rules to RTF core service pods. Available from RTF 2.11.0. | See xref:install-helm.adoc#configure-core-software-high-availability-parameters[Configure Core Software High Availability Parameters].
-|`global.core.tolerations` |Applies Kubernetes tolerations to RTF core service pods, allowing them to be scheduled on nodes with matching taints. Available from RTF 2.11.0. | See xref:install-helm.adoc#configure-core-software-high-availability-parameters[Configure Core Software High Availability Parameters].
+|`global.core.affinity` |Applies Kubernetes affinity and anti-affinity rules to Runtime Fabric core service pods. Available from Runtime Fabric 2.11.0. | See xref:install-helm.adoc#configure-core-software-high-availability-parameters[Configure Core Software High Availability Parameters].
+|`global.core.tolerations` |Applies Kubernetes tolerations to Runtime Fabric core service pods, allowing them to be scheduled on nodes with matching taints. Available from Runtime Fabric 2.11.0. | See xref:install-helm.adoc#configure-core-software-high-availability-parameters[Configure Core Software High Availability Parameters].
 |===
 
 === Configure Core Software High Availability Parameters
@@ -399,7 +399,7 @@ global:
                     - amd64
 ----
 
-You can use `global.core.tolerations` to apply Kubernetes https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[tolerations^] to Runtime Fabric core service pods. Use this to allow core pods to be scheduled on nodes that have specific taints. For example, to tolerate a node tainted with `dedicated=rtf:NoSchedule`:
+You can use `global.core.tolerations` to apply Kubernetes https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[tolerations^] to Runtime Fabric core service pods. Use this to allow Runtime Fabric core pods to be scheduled on nodes that have specific taints. For example, to tolerate a node tainted with `dedicated=rtf:NoSchedule`:
 
 [source,yaml]
 ----


### PR DESCRIPTION
## Summary

- Adds `global.core.tolerations` to the *Configure Core Software High Availability Parameters* section in `install-helm.adoc`, with a description and YAML example showing how to tolerate a node taint
- Adds both `global.core.affinity` and `global.core.tolerations` to the *Optional Parameters* table with RTF 2.11.0+ version callout and cross-references to the HA parameters section
- Both parameters are exposed in `values.yaml` under `global.core`, used in CH2 production, and confirmed safe to document publicly per Sarthak Jain (Engineering SME) in #rtf-hybrid-dev

## GUS

W-20192634

## SME confirmation

Sarthak Jain reviewed a prior docs PR (#1692) and explicitly recommended adding `global.core.tolerations` alongside `global.core.affinity` — same code path, CH2-production-validated, applies to all 4 RTF core deployments. No engineering objections found in #rtf-hybrid-dev or #support-rtf.

## Test plan

- [ ] Verify both new Optional Parameters table rows render correctly
- [ ] Verify the `global.core.tolerations` YAML example renders correctly
- [ ] Confirm xrefs to `#configure-core-software-high-availability-parameters` resolve
- [ ] Confirm no other sections in the page are affected