### PR TITLE
W-23293040: Replace Einstein with AI in view-app-diagnostics

### DIFF
--- a/modules/ROOT/pages/view-app-diagnostics.adoc
+++ b/modules/ROOT/pages/view-app-diagnostics.adoc
@@ -1,6 +1,6 @@
-= Generating Apps Diagnostics and Analyzing with Einstein
+= Generating Apps Diagnostics and Analyzing with AI
 
-Use the MuleSoft diagnostics agent to troubleshoot your Mule applications deployed to Runtime Fabric. This feature leverages Einstein generative AI to automate diagnostics collection and provide intelligent, actionable insights.
+Use the MuleSoft diagnostics agent to troubleshoot your Mule applications deployed to Runtime Fabric. This feature leverages generative AI to automate diagnostics collection and provide intelligent, actionable insights.
 
 == Before you Begin
 
@@ -24,7 +24,7 @@ For Runtime Fabric, verify that you are running these minimum versions:
 . Click the *Analyze & Troubleshoot* dropdown. You have these options:
 ** Select *Generate Mule Diagnostics* to generate and download the diagnostics for manual inspection.
 ... Click *Download* to download the Mule diagnostics files.
-** Select *Analyze with Einstein* to generate the Mule diagnostics and run the analysis simultaneously. 
+** Select *Analyze with AI* to generate the Mule diagnostics and run the analysis simultaneously.
 ... Click *View Analysis* to open the analysis page.
 
 === Generate Mule Diagnostics
@@ -41,8 +41,8 @@ include::partial$diagnostics-agent.adoc[tag=diafFile]
 [NOTE]
 The DIAF doesn’t replace application logs.
 
-=== Analyze with Einstein
-If you select *Analyze with Einstein*, the system generates the Mule diagnostics and runs the Einstein analysis simultaneously. The resulting analysis identifies root causes and recommends actions based on the DIAF file.
+=== Analyze with AI
+If you select *Analyze with AI*, the system generates the Mule diagnostics and runs the AI analysis simultaneously. The resulting analysis identifies root causes and recommends actions based on the DIAF file.
 
 == Considerations and Limitations
 


### PR DESCRIPTION
## Summary

- Renames page title from "Generating Apps Diagnostics and Analyzing with Einstein" to "Generating Apps Diagnostics and Analyzing with AI"
- Removes "Einstein" from page description: "...This feature leverages generative AI..."
- Updates UI label references "*Analyze with Einstein*" to "*Analyze with AI*"
- Renames section heading "=== Analyze with Einstein" to "=== Analyze with AI"
- Updates body text "runs the Einstein analysis" to "runs the AI analysis"

## Rationale

Per CX Product Rebrand Hub guidelines, generative AI features no longer use the "Einstein" brand. "Einstein" is replaced with "AI" throughout. No "formerly known as" note is needed for description/body text.

## Test plan

- [ ] Verify page renders correctly at `https://docs.mulesoft.com/runtime-fabric/latest/view-app-diagnostics`
- [ ] Confirm no remaining "Einstein" references in the file