### PR TITLE
W-23365932-hyperforce-australia-cloud-rtf-kt

### DIFF
--- a/modules/ROOT/pages/_partials/include-manage-proxies.adoc
+++ b/modules/ROOT/pages/_partials/include-manage-proxies.adoc
@@ -25,6 +25,9 @@ The SOCKS5 proxy must connect to Anypoint Monitoring over TCP at the following e
 * India Cloud: +
 `ingest.in1.platform.mulesoft.com`
 
+* Australia Cloud: +
+`ingest.au1.platform.mulesoft.com`
+
 . Log in to a node where `rtfctl` is installed. 
 . Run the following command, replacing the placeholder values with the following:
 +

--- a/modules/ROOT/pages/_partials/rtfctl-commands.adoc
+++ b/modules/ROOT/pages/_partials/rtfctl-commands.adoc
@@ -352,6 +352,12 @@ rtfctl update --host jp1.platform.mulesoft.com
 rtfctl update --host in1.platform.mulesoft.com
 ----
 
+* Updates `rtfctl` from the Australia Cloud
++
+----
+rtfctl update --host au1.platform.mulesoft.com
+----
+
 [[wait]]
 = `wait`
 Waits for Runtime Fabric components to become ready

--- a/modules/ROOT/pages/configure-local-registry.adoc
+++ b/modules/ROOT/pages/configure-local-registry.adoc
@@ -107,7 +107,7 @@ done
 * Canada Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-58ktaz.svc.sfdcfc.net`
 * Japan Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-mchho0.svc.sfdcfc.net`
 * India Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-y37hzm.svc.sfdcfc.net`
-* Australia Cloud: `rtf-runtime-registry-mulesoft-cp.<placeholder>.svc.sfdcfc.net`
+* Australia Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-vwfla6.svc.sfdcfc.net`
 | `image-path` a| Image namespace path on the registry.
 
 * US Cloud and EU Cloud: `mulesoft`

--- a/modules/ROOT/pages/configure-local-registry.adoc
+++ b/modules/ROOT/pages/configure-local-registry.adoc
@@ -107,14 +107,15 @@ done
 * Canada Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-58ktaz.svc.sfdcfc.net`
 * Japan Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-mchho0.svc.sfdcfc.net`
 * India Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-y37hzm.svc.sfdcfc.net`
+* Australia Cloud: `rtf-runtime-registry-mulesoft-cp.<placeholder>.svc.sfdcfc.net`
 | `image-path` a| Image namespace path on the registry.
 
 * US Cloud and EU Cloud: `mulesoft`
-* Canada Cloud, Japan Cloud, and India Cloud: `sfci/mulesoft/ms-docker-image`
+* Canada Cloud, Japan Cloud, India Cloud, and Australia Cloud: `sfci/mulesoft/ms-docker-image`
 |===
 
 [NOTE]
-For Canada Cloud, Japan Cloud, and India Cloud, images in the SFCI registry use an `ms-` prefix in the artifact name (for example, `ms-rtf-agent` instead of `rtf-agent`). The automated script does not account for this prefix difference, so you must manually prepend `ms-` to each artifact name when pulling from the SFCI registry for these regions.
+For Canada Cloud, Japan Cloud, India Cloud, and Australia Cloud, images in the SFCI registry use an `ms-` prefix in the artifact name (for example, `ms-rtf-agent` instead of `rtf-agent`). The automated script does not account for this prefix difference, so you must manually prepend `ms-` to each artifact name when pulling from the SFCI registry for these regions.
 
 --
 Synchronize Manually:: 
@@ -172,6 +173,15 @@ For the India Cloud:
 # docker tag rtf-runtime-registry-mulesoft-cp.sfdc-y37hzm.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/ms-rtf-agent:v1.12.0 <docker-server>/mulesoft/rtf-agent:v1.12.0
 # docker push <docker-server>/mulesoft/rtf-agent:v1.12.0
 ----
++
+For the Australia Cloud:
++
+[source,copy]
+----
+# docker pull rtf-runtime-registry-mulesoft-cp.<placeholder>.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/ms-rtf-agent:v1.12.0
+# docker tag rtf-runtime-registry-mulesoft-cp.<placeholder>.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/ms-rtf-agent:v1.12.0 <docker-server>/mulesoft/rtf-agent:v1.12.0
+# docker push <docker-server>/mulesoft/rtf-agent:v1.12.0
+----
 --
 ====
 
@@ -188,11 +198,12 @@ To synchronize the Mule runtime versions you plan to use for application deploym
 | Canada Cloud | `rtf-runtime-registry-mulesoft-cp.sfdc-58ktaz.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/<image>:<tag>`
 | Japan Cloud | `rtf-runtime-registry-mulesoft-cp.sfdc-mchho0.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/<image>:<tag>`
 | India Cloud | `rtf-runtime-registry-mulesoft-cp.sfdc-y37hzm.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/<image>:<tag>`
+| Australia Cloud | `rtf-runtime-registry-mulesoft-cp.<placeholder>.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/<image>:<tag>`
 |===
 
 [NOTE]
 ====
-For Canada Cloud, Japan Cloud, and India Cloud deployments on OpenShift, download these images from the SFCI registry:
+For Canada Cloud, Japan Cloud, India Cloud, and Australia Cloud deployments on OpenShift, download these images from the SFCI registry:
 
 * Mule runtime: `/sfci/mulesoft/ms-docker-image/ms-poseidon-runtime-<version>:<tag>`
 * Anypoint Monitoring sidecar: `/sfci/mulesoft/ms-docker-image/ms-dias-anypoint-monitoring-sidecar-ubi:<version>`
@@ -247,8 +258,17 @@ For the India Cloud:
 # docker push <docker-server>/mulesoft/<image>:<tag>
 ----
 
+For the Australia Cloud:
+
+[source,copy]
+----
+# docker pull rtf-runtime-registry-mulesoft-cp.<placeholder>.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/ms-<image>:<tag>
+# docker tag rtf-runtime-registry-mulesoft-cp.<placeholder>.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/ms-<image>:<tag> <docker-server>/mulesoft/<image>:<tag>
+# docker push <docker-server>/mulesoft/<image>:<tag>
+----
+
 [NOTE]
-For Canada Cloud, Japan Cloud, and India Cloud, the source image in the SFCI registry uses an `ms-` prefix in the artifact name (for example, `ms-<image>`). When you retag the image for your local registry, drop the `ms-` prefix so that Runtime Fabric can pull it using the expected name.
+For Canada Cloud, Japan Cloud, India Cloud, and Australia Cloud, the source image in the SFCI registry uses an `ms-` prefix in the artifact name (for example, `ms-<image>`). When you retag the image for your local registry, drop the `ms-` prefix so that Runtime Fabric can pull it using the expected name.
 
 == Configure Your Local Registry for Runtime Fabric
 

--- a/modules/ROOT/pages/configure-local-registry.adoc
+++ b/modules/ROOT/pages/configure-local-registry.adoc
@@ -178,8 +178,8 @@ For the Australia Cloud:
 +
 [source,copy]
 ----
-# docker pull rtf-runtime-registry-mulesoft-cp.<placeholder>.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/ms-rtf-agent:v1.12.0
-# docker tag rtf-runtime-registry-mulesoft-cp.<placeholder>.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/ms-rtf-agent:v1.12.0 <docker-server>/mulesoft/rtf-agent:v1.12.0
+# docker pull rtf-runtime-registry-mulesoft-cp.sfdc-vwfla6.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/ms-rtf-agent:v1.12.0
+# docker tag rtf-runtime-registry-mulesoft-cp.sfdc-vwfla6.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/ms-rtf-agent:v1.12.0 <docker-server>/mulesoft/rtf-agent:v1.12.0
 # docker push <docker-server>/mulesoft/rtf-agent:v1.12.0
 ----
 --
@@ -195,9 +195,9 @@ To synchronize the Mule runtime versions you plan to use for application deploym
 | Control Plane | Image Location Format
 | US Cloud | `rtf-runtime-registry.kprod.msap.io/mulesoft/<image>:<tag>`
 | EU Cloud | `rtf-runtime-registry.kprod-eu.msap.io/mulesoft/<image>:<tag>`
-| Canada Cloud | `rtf-runtime-registry-mulesoft-cp.sfdc-58ktaz.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/<image>:<tag>`
-| Japan Cloud | `rtf-runtime-registry-mulesoft-cp.sfdc-mchho0.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/<image>:<tag>`
-| India Cloud | `rtf-runtime-registry-mulesoft-cp.sfdc-y37hzm.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/<image>:<tag>`
+| Canada Cloud | `rtf-runtime-registry-mulesoft-cp.sfdc-58ktaz.svc.sfdcfc.net/v2/sfci/mulesoft/ms-docker-image/<image>:<tag>`
+| Japan Cloud | `rtf-runtime-registry-mulesoft-cp.sfdc-mchho0.svc.sfdcfc.net/v2/sfci/mulesoft/ms-docker-image/<image>:<tag>`
+| India Cloud | `rtf-runtime-registry-mulesoft-cp.sfdc-y37hzm.svc.sfdcfc.net/v2/sfci/mulesoft/ms-docker-image/<image>:<tag>`
 | Australia Cloud | `rtf-runtime-registry-mulesoft-cp.sfdc-vwfla6.svc.sfdcfc.net/v2/sfci/mulesoft/ms-docker-image/<image>:<tag>`
 |===
 
@@ -262,8 +262,8 @@ For the Australia Cloud:
 
 [source,copy]
 ----
-# docker pull rtf-runtime-registry-mulesoft-cp.<placeholder>.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/ms-<image>:<tag>
-# docker tag rtf-runtime-registry-mulesoft-cp.<placeholder>.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/ms-<image>:<tag> <docker-server>/mulesoft/<image>:<tag>
+# docker pull rtf-runtime-registry-mulesoft-cp.sfdc-vwfla6.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/ms-<image>:<tag>
+# docker tag rtf-runtime-registry-mulesoft-cp.sfdc-vwfla6.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/ms-<image>:<tag> <docker-server>/mulesoft/<image>:<tag>
 # docker push <docker-server>/mulesoft/<image>:<tag>
 ----
 

--- a/modules/ROOT/pages/configure-local-registry.adoc
+++ b/modules/ROOT/pages/configure-local-registry.adoc
@@ -198,7 +198,7 @@ To synchronize the Mule runtime versions you plan to use for application deploym
 | Canada Cloud | `rtf-runtime-registry-mulesoft-cp.sfdc-58ktaz.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/<image>:<tag>`
 | Japan Cloud | `rtf-runtime-registry-mulesoft-cp.sfdc-mchho0.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/<image>:<tag>`
 | India Cloud | `rtf-runtime-registry-mulesoft-cp.sfdc-y37hzm.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/<image>:<tag>`
-| Australia Cloud | `rtf-runtime-registry-mulesoft-cp.<placeholder>.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/<image>:<tag>`
+| Australia Cloud | `rtf-runtime-registry-mulesoft-cp.sfdc-vwfla6.svc.sfdcfc.net/v2/sfci/mulesoft/ms-docker-image/<image>:<tag>`
 |===
 
 [NOTE]

--- a/modules/ROOT/pages/install-helm.adoc
+++ b/modules/ROOT/pages/install-helm.adoc
@@ -279,7 +279,7 @@ These required values are created and added to `values.yml` when you create the 
 * Canada: `rtf-runtime-registry-mulesoft-cp.sfdc-58ktaz.svc.sfdcfc.net`
 * Japan: `rtf-runtime-registry-mulesoft-cp.sfdc-mchho0.svc.sfdcfc.net`
 * India Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-y37hzm.svc.sfdcfc.net`
-* Australia Cloud: `rtf-runtime-registry-mulesoft-cp.<placeholder>.svc.sfdcfc.net`
+* Australia Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-vwfla6.svc.sfdcfc.net`
 |`pullSecretName` |Registry secret |`<pull_secret>`
 |`muleLicense` |Mule license for applications |`<mule_license_key>`. Must be Base64 encoded.
 |===

--- a/modules/ROOT/pages/install-helm.adoc
+++ b/modules/ROOT/pages/install-helm.adoc
@@ -438,7 +438,7 @@ For example:
 * Canada Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-58ktaz.svc.sfdcfc.net/charts`
 * Japan Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-mchho0.svc.sfdcfc.net/charts`
 * India Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-y37hzm.svc.sfdcfc.net/charts`
-* Australia Cloud: `rtf-runtime-registry-mulesoft-cp.<placeholder>.svc.sfdcfc.net/charts`
+* Australia Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-vwfla6.svc.sfdcfc.net/charts`
 
 == See Also
 

--- a/modules/ROOT/pages/install-helm.adoc
+++ b/modules/ROOT/pages/install-helm.adoc
@@ -262,7 +262,7 @@ global:
 ----
 
 [NOTE]
-If you are configuring a Runtime Fabric BYOK for a non-US Cloud region (EU Cloud, Canada Cloud, Japan Cloud, or India Cloud), review the changes in xref:runtime-fabric::install-self-managed-network-configuration.adoc#hostname-configuration[Hostname Configuration] for a correct configuration. Set the `rtfRegistry` property to the registry URL for your cloud region.
+If you are configuring a Runtime Fabric BYOK for a non-US Cloud region (EU Cloud, Canada Cloud, Japan Cloud, India Cloud, or Australia Cloud), review the changes in xref:runtime-fabric::install-self-managed-network-configuration.adoc#hostname-configuration[Hostname Configuration] for a correct configuration. Set the `rtfRegistry` property to the registry URL for your cloud region.
 
 [[required-parameters]]
 === Required Parameters
@@ -279,6 +279,7 @@ These required values are created and added to `values.yml` when you create the 
 * Canada: `rtf-runtime-registry-mulesoft-cp.sfdc-58ktaz.svc.sfdcfc.net`
 * Japan: `rtf-runtime-registry-mulesoft-cp.sfdc-mchho0.svc.sfdcfc.net`
 * India Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-y37hzm.svc.sfdcfc.net`
+* Australia Cloud: `rtf-runtime-registry-mulesoft-cp.<placeholder>.svc.sfdcfc.net`
 |`pullSecretName` |Registry secret |`<pull_secret>`
 |`muleLicense` |Mule license for applications |`<mule_license_key>`. Must be Base64 encoded.
 |===
@@ -437,6 +438,7 @@ For example:
 * Canada Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-58ktaz.svc.sfdcfc.net/charts`
 * Japan Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-mchho0.svc.sfdcfc.net/charts`
 * India Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-y37hzm.svc.sfdcfc.net/charts`
+* Australia Cloud: `rtf-runtime-registry-mulesoft-cp.<placeholder>.svc.sfdcfc.net/charts`
 
 == See Also
 

--- a/modules/ROOT/pages/install-self-managed-network-configuration.adoc
+++ b/modules/ROOT/pages/install-self-managed-network-configuration.adoc
@@ -135,6 +135,22 @@ This table lists the required hostname endpoint configurations for the India Clo
 | 443 | HTTPS | `prod-us-east-1-starport-layer-bucket.s3.us-east-1.amazonaws.com` | Runtime Fabric Docker image delivery.
 |===
 
+=== Australia Cloud
+
+This table lists the required hostname endpoint configurations for the Australia Cloud.
+
+[%header,cols="4*a"]
+|===
+| Port | Protocol | Hostnames | Description
+| 8443 | WSS | `runtime-manager.au1.platform.mulesoft.com` | Runtime Fabric message broker for interaction with the control plane (path: `/v1/connect`).
+| 443 | HTTPS | `au1.platform.mulesoft.com` | Anypoint Platform for agent bootstrapping and certificate renewal.
+| 8443 | HTTPS | `runtime-manager.au1.platform.mulesoft.com` | Configuration Resolver, Exchange asset download, and Runtime Manager services. In the Australia Cloud, these services are consolidated behind a single endpoint (path: `/resolver`).
+| 8443 | HTTPS | `ingest.au1.platform.mulesoft.com` | xref:use-anypoint-monitoring.adoc#enable-anypoint-monitoring[Anypoint Monitoring] agent for Runtime Fabric (logs, metrics, and traces ingestion via OTEL).
+| 443 | HTTPS | `rtf-runtime-registry-mulesoft-cp.<placeholder>.svc.sfdcfc.net` | Runtime Fabric Docker and Helm chart repository. All container images (Mule runtime, monitoring sidecars, and Runtime Fabric agent) are pulled from this registry.
+| 443 | HTTPS | `esvc-us-east-2-mulesoft.s3.us-east-2.amazonaws.com` | Runtime Fabric installer chart tarball. Required only for `rtfctl`-based installations.
+| 443 | HTTPS | `prod-us-east-1-starport-layer-bucket.s3.us-east-1.amazonaws.com` | Runtime Fabric Docker image delivery.
+|===
+
 == Verify Outbound Connectivity
 
 Every Anypoint Runtime Fabric cluster requires connectivity with Anypoint control plane, and any interference with connectivity can limit functionality, resulting in application deployment failures or degraded status in Anypoint Runtime Manager.
@@ -188,4 +204,7 @@ To allow different endpoints to use mutual TLS authentication to establish a con
 | India Cloud | `runtime-manager.in1.platform.mulesoft.com` | 8443 | WSS | Message broker (mTLS, path: `/v1/connect`)
 | India Cloud | `runtime-manager.in1.platform.mulesoft.com` | 8443 | HTTPS | Configuration Resolver and Runtime Manager services (consolidated endpoint, path: `/resolver`)
 | India Cloud | `ingest.in1.platform.mulesoft.com` | 8443 | HTTPS | Anypoint Monitoring ingest (OTEL)
+| Australia Cloud | `runtime-manager.au1.platform.mulesoft.com` | 8443 | WSS | Message broker (mTLS, path: `/v1/connect`)
+| Australia Cloud | `runtime-manager.au1.platform.mulesoft.com` | 8443 | HTTPS | Configuration Resolver and Runtime Manager services (consolidated endpoint, path: `/resolver`)
+| Australia Cloud | `ingest.au1.platform.mulesoft.com` | 8443 | HTTPS | Anypoint Monitoring ingest (OTEL)
 |===

--- a/modules/ROOT/pages/install-self-managed-network-configuration.adoc
+++ b/modules/ROOT/pages/install-self-managed-network-configuration.adoc
@@ -146,7 +146,7 @@ This table lists the required hostname endpoint configurations for the Australia
 | 443 | HTTPS | `au1.platform.mulesoft.com` | Anypoint Platform for agent bootstrapping and certificate renewal.
 | 8443 | HTTPS | `runtime-manager.au1.platform.mulesoft.com` | Configuration Resolver, Exchange asset download, and Runtime Manager services. In the Australia Cloud, these services are consolidated behind a single endpoint (path: `/resolver`).
 | 8443 | HTTPS | `ingest.au1.platform.mulesoft.com` | xref:use-anypoint-monitoring.adoc#enable-anypoint-monitoring[Anypoint Monitoring] agent for Runtime Fabric (logs, metrics, and traces ingestion via OTEL).
-| 443 | HTTPS | `rtf-runtime-registry-mulesoft-cp.<placeholder>.svc.sfdcfc.net` | Runtime Fabric Docker and Helm chart repository. All container images (Mule runtime, monitoring sidecars, and Runtime Fabric agent) are pulled from this registry.
+| 443 | HTTPS | `rtf-runtime-registry-mulesoft-cp.sfdc-vwfla6.svc.sfdcfc.net` | Runtime Fabric Docker and Helm chart repository. All container images (Mule runtime, monitoring sidecars, and Runtime Fabric agent) are pulled from this registry.
 | 443 | HTTPS | `esvc-us-east-2-mulesoft.s3.us-east-2.amazonaws.com` | Runtime Fabric installer chart tarball. Required only for `rtfctl`-based installations.
 | 443 | HTTPS | `prod-us-east-1-starport-layer-bucket.s3.us-east-1.amazonaws.com` | Runtime Fabric Docker image delivery.
 |===


### PR DESCRIPTION
## Summary

Replicates India Cloud changes from PR #1710 for Australia Cloud (`au1.platform.mulesoft.com`).

- **`_partials/include-manage-proxies.adoc`**: Added `ingest.au1.platform.mulesoft.com` to SOCKS5 proxy endpoint list.
- **`_partials/rtfctl-commands.adoc`**: Added `rtfctl update --host au1.platform.mulesoft.com` example.
- **`configure-local-registry.adoc`**: Added Australia Cloud to `mulesoft-docker-server` parameter table, Synchronize Manually docker commands, Synchronize Mule Runtime Images table, and Mule runtime docker commands section. Updated notes referencing Canada/Japan/India to include Australia.
- **`install-helm.adoc`**: Added Australia Cloud to BYOK note, `rtfRegistry` required parameters table, and Helm charts URL list.
- **`install-self-managed-network-configuration.adoc`**: Added new `=== Australia Cloud` hostname configuration section and Australia Cloud rows to the SSL passthrough/mTLS table.

## Notes

- Registry SFCI ID for Australia Cloud is unknown — using `<placeholder>` throughout. Update when the actual SFCI registry ID is available.
- Platform URL: `au1.platform.mulesoft.com`

## Test plan

- [ ] Verify placeholder registry URLs are updated before publishing once the actual SFCI ID for Australia Cloud is confirmed.
- [ ] Review hostname patterns follow the same structure as India Cloud.