### PR TITLE
W-23748914: Add United Kingdom Cloud to Runtime Fabric self-managed docs

### DIFF
--- a/modules/ROOT/pages/_partials/include-manage-proxies.adoc
+++ b/modules/ROOT/pages/_partials/include-manage-proxies.adoc
@@ -28,6 +28,9 @@ The SOCKS5 proxy must connect to Anypoint Monitoring over TCP at the following e
 * Australia Cloud: +
 `ingest.au1.platform.mulesoft.com`
 
+* United Kingdom Cloud: +
+`ingest.gb1.platform.mulesoft.com`
+
 . Log in to a node where `rtfctl` is installed. 
 . Run the following command, replacing the placeholder values with the following:
 +

--- a/modules/ROOT/pages/_partials/rtfctl-commands.adoc
+++ b/modules/ROOT/pages/_partials/rtfctl-commands.adoc
@@ -358,6 +358,12 @@ rtfctl update --host in1.platform.mulesoft.com
 rtfctl update --host au1.platform.mulesoft.com
 ----
 
+* Updates `rtfctl` from the United Kingdom Cloud
++
+----
+rtfctl update --host gb1.platform.mulesoft.com
+----
+
 [[wait]]
 = `wait`
 Waits for Runtime Fabric components to become ready

--- a/modules/ROOT/pages/configure-local-registry.adoc
+++ b/modules/ROOT/pages/configure-local-registry.adoc
@@ -108,14 +108,15 @@ done
 * Japan Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-mchho0.svc.sfdcfc.net`
 * India Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-y37hzm.svc.sfdcfc.net`
 * Australia Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-vwfla6.svc.sfdcfc.net`
+* United Kingdom Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-<placeholder>.svc.sfdcfc.net`
 | `image-path` a| Image namespace path on the registry.
 
 * US Cloud and EU Cloud: `mulesoft`
-* Canada Cloud, Japan Cloud, India Cloud, and Australia Cloud: `sfci/mulesoft/ms-docker-image`
+* Canada Cloud, Japan Cloud, India Cloud, Australia Cloud, and United Kingdom Cloud: `sfci/mulesoft/ms-docker-image`
 |===
 
 [NOTE]
-For Canada Cloud, Japan Cloud, India Cloud, and Australia Cloud, images in the SFCI registry use an `ms-` prefix in the artifact name (for example, `ms-rtf-agent` instead of `rtf-agent`). The automated script does not account for this prefix difference, so you must manually prepend `ms-` to each artifact name when pulling from the SFCI registry for these regions.
+For Canada Cloud, Japan Cloud, India Cloud, Australia Cloud, and United Kingdom Cloud, images in the SFCI registry use an `ms-` prefix in the artifact name (for example, `ms-rtf-agent` instead of `rtf-agent`). The automated script does not account for this prefix difference, so you must manually prepend `ms-` to each artifact name when pulling from the SFCI registry for these regions.
 
 --
 Synchronize Manually:: 
@@ -182,6 +183,15 @@ For the Australia Cloud:
 # docker tag rtf-runtime-registry-mulesoft-cp.sfdc-vwfla6.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/ms-rtf-agent:v1.12.0 <docker-server>/mulesoft/rtf-agent:v1.12.0
 # docker push <docker-server>/mulesoft/rtf-agent:v1.12.0
 ----
++
+For the United Kingdom Cloud:
++
+[source,copy]
+----
+# docker pull rtf-runtime-registry-mulesoft-cp.sfdc-<placeholder>.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/ms-rtf-agent:v1.12.0
+# docker tag rtf-runtime-registry-mulesoft-cp.sfdc-<placeholder>.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/ms-rtf-agent:v1.12.0 <docker-server>/mulesoft/rtf-agent:v1.12.0
+# docker push <docker-server>/mulesoft/rtf-agent:v1.12.0
+----
 --
 ====
 
@@ -199,11 +209,12 @@ To synchronize the Mule runtime versions you plan to use for application deploym
 | Japan Cloud | `rtf-runtime-registry-mulesoft-cp.sfdc-mchho0.svc.sfdcfc.net/v2/sfci/mulesoft/ms-docker-image/<image>:<tag>`
 | India Cloud | `rtf-runtime-registry-mulesoft-cp.sfdc-y37hzm.svc.sfdcfc.net/v2/sfci/mulesoft/ms-docker-image/<image>:<tag>`
 | Australia Cloud | `rtf-runtime-registry-mulesoft-cp.sfdc-vwfla6.svc.sfdcfc.net/v2/sfci/mulesoft/ms-docker-image/<image>:<tag>`
+| United Kingdom Cloud | `rtf-runtime-registry-mulesoft-cp.sfdc-<placeholder>.svc.sfdcfc.net/v2/sfci/mulesoft/ms-docker-image/<image>:<tag>`
 |===
 
 [NOTE]
 ====
-For Canada Cloud, Japan Cloud, India Cloud, and Australia Cloud deployments on OpenShift, download these images from the SFCI registry:
+For Canada Cloud, Japan Cloud, India Cloud, Australia Cloud, and United Kingdom Cloud deployments on OpenShift, download these images from the SFCI registry:
 
 * Mule runtime: `/sfci/mulesoft/ms-docker-image/ms-poseidon-runtime-<version>:<tag>`
 * Anypoint Monitoring sidecar: `/sfci/mulesoft/ms-docker-image/ms-dias-anypoint-monitoring-sidecar-ubi:<version>`
@@ -267,8 +278,17 @@ For the Australia Cloud:
 # docker push <docker-server>/mulesoft/<image>:<tag>
 ----
 
+For the United Kingdom Cloud:
+
+[source,copy]
+----
+# docker pull rtf-runtime-registry-mulesoft-cp.sfdc-<placeholder>.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/ms-<image>:<tag>
+# docker tag rtf-runtime-registry-mulesoft-cp.sfdc-<placeholder>.svc.sfdcfc.net/sfci/mulesoft/ms-docker-image/ms-<image>:<tag> <docker-server>/mulesoft/<image>:<tag>
+# docker push <docker-server>/mulesoft/<image>:<tag>
+----
+
 [NOTE]
-For Canada Cloud, Japan Cloud, India Cloud, and Australia Cloud, the source image in the SFCI registry uses an `ms-` prefix in the artifact name (for example, `ms-<image>`). When you retag the image for your local registry, drop the `ms-` prefix so that Runtime Fabric can pull it using the expected name.
+For Canada Cloud, Japan Cloud, India Cloud, Australia Cloud, and United Kingdom Cloud, the source image in the SFCI registry uses an `ms-` prefix in the artifact name (for example, `ms-<image>`). When you retag the image for your local registry, drop the `ms-` prefix so that Runtime Fabric can pull it using the expected name.
 
 == Configure Your Local Registry for Runtime Fabric
 

--- a/modules/ROOT/pages/install-helm.adoc
+++ b/modules/ROOT/pages/install-helm.adoc
@@ -262,7 +262,7 @@ global:
 ----
 
 [NOTE]
-If you are configuring a Runtime Fabric BYOK for a non-US Cloud region (EU Cloud, Canada Cloud, Japan Cloud, India Cloud, or Australia Cloud), review the changes in xref:runtime-fabric::install-self-managed-network-configuration.adoc#hostname-configuration[Hostname Configuration] for a correct configuration. Set the `rtfRegistry` property to the registry URL for your cloud region.
+If you are configuring a Runtime Fabric BYOK for a non-US Cloud region (EU Cloud, Canada Cloud, Japan Cloud, India Cloud, Australia Cloud, or United Kingdom Cloud), review the changes in xref:runtime-fabric::install-self-managed-network-configuration.adoc#hostname-configuration[Hostname Configuration] for a correct configuration. Set the `rtfRegistry` property to the registry URL for your cloud region.
 
 [[required-parameters]]
 === Required Parameters
@@ -280,6 +280,7 @@ These required values are created and added to `values.yml` when you create the 
 * Japan: `rtf-runtime-registry-mulesoft-cp.sfdc-mchho0.svc.sfdcfc.net`
 * India Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-y37hzm.svc.sfdcfc.net`
 * Australia Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-vwfla6.svc.sfdcfc.net`
+* United Kingdom Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-<placeholder>.svc.sfdcfc.net`
 |`pullSecretName` |Registry secret |`<pull_secret>`
 |`muleLicense` |Mule license for applications |`<mule_license_key>`. Must be Base64 encoded.
 |===
@@ -439,6 +440,7 @@ For example:
 * Japan Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-mchho0.svc.sfdcfc.net/charts`
 * India Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-y37hzm.svc.sfdcfc.net/charts`
 * Australia Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-vwfla6.svc.sfdcfc.net/charts`
+* United Kingdom Cloud: `rtf-runtime-registry-mulesoft-cp.sfdc-<placeholder>.svc.sfdcfc.net/charts`
 
 == See Also
 

--- a/modules/ROOT/pages/install-self-managed-network-configuration.adoc
+++ b/modules/ROOT/pages/install-self-managed-network-configuration.adoc
@@ -151,6 +151,22 @@ This table lists the required hostname endpoint configurations for the Australia
 | 443 | HTTPS | `prod-us-east-1-starport-layer-bucket.s3.us-east-1.amazonaws.com` | Runtime Fabric Docker image delivery.
 |===
 
+=== United Kingdom Cloud
+
+This table lists the required hostname endpoint configurations for the United Kingdom Cloud.
+
+[%header,cols="4*a"]
+|===
+| Port | Protocol | Hostnames | Description
+| 8443 | WSS | `runtime-manager.gb1.platform.mulesoft.com` | Runtime Fabric message broker for interaction with the control plane (path: `/v1/connect`).
+| 443 | HTTPS | `gb1.platform.mulesoft.com` | Anypoint Platform for agent bootstrapping and certificate renewal.
+| 8443 | HTTPS | `runtime-manager.gb1.platform.mulesoft.com` | Configuration Resolver, Exchange asset download, and Runtime Manager services. In the United Kingdom Cloud, these services are consolidated behind a single endpoint (path: `/resolver`).
+| 8443 | HTTPS | `ingest.gb1.platform.mulesoft.com` | xref:use-anypoint-monitoring.adoc#enable-anypoint-monitoring[Anypoint Monitoring] agent for Runtime Fabric (logs, metrics, and traces ingestion via OTEL).
+| 443 | HTTPS | `rtf-runtime-registry-mulesoft-cp.sfdc-<placeholder>.svc.sfdcfc.net` | Runtime Fabric Docker and Helm chart repository. All container images (Mule runtime, monitoring sidecars, and Runtime Fabric agent) are pulled from this registry.
+| 443 | HTTPS | `esvc-us-east-2-mulesoft.s3.us-east-2.amazonaws.com` | Runtime Fabric installer chart tarball. Required only for `rtfctl`-based installations.
+| 443 | HTTPS | `prod-us-east-1-starport-layer-bucket.s3.us-east-1.amazonaws.com` | Runtime Fabric Docker image delivery.
+|===
+
 == Verify Outbound Connectivity
 
 Every Anypoint Runtime Fabric cluster requires connectivity with Anypoint control plane, and any interference with connectivity can limit functionality, resulting in application deployment failures or degraded status in Anypoint Runtime Manager.
@@ -207,4 +223,7 @@ To allow different endpoints to use mutual TLS authentication to establish a con
 | Australia Cloud | `runtime-manager.au1.platform.mulesoft.com` | 8443 | WSS | Message broker (mTLS, path: `/v1/connect`)
 | Australia Cloud | `runtime-manager.au1.platform.mulesoft.com` | 8443 | HTTPS | Configuration Resolver and Runtime Manager services (consolidated endpoint, path: `/resolver`)
 | Australia Cloud | `ingest.au1.platform.mulesoft.com` | 8443 | HTTPS | Anypoint Monitoring ingest (OTEL)
+| United Kingdom Cloud | `runtime-manager.gb1.platform.mulesoft.com` | 8443 | WSS | Message broker (mTLS, path: `/v1/connect`)
+| United Kingdom Cloud | `runtime-manager.gb1.platform.mulesoft.com` | 8443 | HTTPS | Configuration Resolver and Runtime Manager services (consolidated endpoint, path: `/resolver`)
+| United Kingdom Cloud | `ingest.gb1.platform.mulesoft.com` | 8443 | HTTPS | Anypoint Monitoring ingest (OTEL)
 |===


### PR DESCRIPTION
## Summary

Replicates the Australia Cloud changes from PR #1730 for United Kingdom Cloud (`gb1.platform.mulesoft.com`).

- **`_partials/include-manage-proxies.adoc`**: Added `ingest.gb1.platform.mulesoft.com` to the SOCKS5 proxy endpoint list.
- **`_partials/rtfctl-commands.adoc`**: Added `rtfctl update --host gb1.platform.mulesoft.com` example.
- **`configure-local-registry.adoc`**: Added United Kingdom Cloud to the registry parameter table, docker command blocks, and the Synchronize Mule Runtime Images table; updated notes to include United Kingdom Cloud.
- **`install-helm.adoc`**: Added United Kingdom Cloud to the BYOK note, `rtfRegistry` parameters table, and Helm charts URL list.
- **`install-self-managed-network-configuration.adoc`**: Added a new `=== United Kingdom Cloud` hostname configuration section and United Kingdom Cloud rows to the mTLS table.

## Notes

- **Registry SFCI ID is unknown** — using placeholder `sfdc-<placeholder>` throughout. Update when the actual SFCI registry ID for United Kingdom Cloud is confirmed.
- Platform URL: `gb1.platform.mulesoft.com`; AWS region `eu-west-2`.

Made with [Cursor](https://cursor.com)