### PR TITLE
W-23807411-rtf-agent-version-kt

### DIFF
--- a/modules/ROOT/pages/view-app-diagnostics.adoc
+++ b/modules/ROOT/pages/view-app-diagnostics.adoc
@@ -10,7 +10,7 @@ include::partial$diagnostics-agent.adoc[tag=prerequisites]
 
 For Runtime Fabric, verify that you are running these minimum versions:
 
-* `rtf-agent` <TBD>
+* `rtf-agent` 3.0.102
 * `rtf-mule-actions` 2.0.7
 
 


### PR DESCRIPTION
## Summary

Replaces the `<TBD>` placeholder for the `rtf-agent` minimum version in the diagnostics agent *Before you Begin* section with `3.0.102`.

- File: `modules/ROOT/pages/view-app-diagnostics.adoc`
- GUS: W-23807411 — "RTF - Diagnostics Agent - Missing Minimum Requirements Information"

## Sources

- GUS W-23807411 — the doc request; specifies `3.0.102` based on requester research.
- [Runtime Fabric 3.x.x release notes, §3.0.102](https://docs.mulesoft.com/release-notes/runtime-fabric/runtime-fabric-release-notes-3.x.x#3-0-102) (May 28, 2026) — confirms `mulesoft/rtf-agent:3.0.102` and lists the diagnostics feature as supported.

## Note for reviewers

The "Generating Apps Diagnostics… is supported" note also appears under earlier releases (3.0.1, 3.0.43). The ticket, requester research, and named contacts (Amit Shorey, Ankur Sethi) all specify 3.0.102, which is used here.