### PR TITLE
W-23982972-rtf-oke-support-kt

### DIFF
--- a/modules/ROOT/pages/authorized-namespaces.adoc
+++ b/modules/ROOT/pages/authorized-namespaces.adoc
@@ -97,7 +97,7 @@ roleRef:
 
 You configure authorized namespaces when you install Runtime Fabric. Refer to the appropriate installation instructions:
 
-* xref:install-helm.adoc[Installing Runtime Fabric on EKS, AKS, and GKE Using Helm]
+* xref:install-helm.adoc[Installing Runtime Fabric on EKS, AKS, GKE, and OKE Using Helm]
 * xref:install-openshift.adoc[Install Runtime Fabric on Red Hat OpenShift]
 
 == Add New Namespaces

--- a/modules/ROOT/pages/index-vm-bare-metal.adoc
+++ b/modules/ROOT/pages/index-vm-bare-metal.adoc
@@ -28,6 +28,7 @@ Existing appliance utility users can migrate the licensed Core capacity currentl
 ** https://aws.amazon.com/eks/eks-anywhere/[Runtime Fabric on AWS EKS-Anywhere^]
 ** https://developer.mulesoft.com/tutorials-and-howtos/runtime-fabric/runtime-fabric-azure-kubernetes-service/[Runtime Fabric on Google Kubernetes Engine^]
 ** https://developer.mulesoft.com/tutorials-and-howtos/runtime-fabric/runtime-fabric-google-kubernetes-engine/[Runtime Fabric on Microsoft Azure Kubernetes Service^]
+** https://www.oracle.com/cloud/cloud-native/kubernetes-engine/[Runtime Fabric on Oracle Kubernetes Engine^]
 
 
 

--- a/modules/ROOT/pages/index-vm-bare-metal.adoc
+++ b/modules/ROOT/pages/index-vm-bare-metal.adoc
@@ -11,7 +11,7 @@ Depending on your affinity to public clouds and in-house Kubernetes expertise, t
 * https://www.redhat.com/en/technologies/cloud-computing/openshift/container-platform[Red Hat OpenShift Container Platform (OCP)^]
 * https://www.redhat.com/en/technologies/cloud-computing/openshift/platform-plus[Red Hat OpenShift Platform Plus^]
 
-After you use one of these solutions to set up K8s on the cluster, proceed to the Runtime Fabric installation section to set up Runtime Fabric as you would install on an AKS or EKS. 
+After you use one of these solutions to set up K8s on the cluster, proceed to the Runtime Fabric installation section to set up Runtime Fabric as you would install on an AKS, EKS, or OKE. 
 
 
 == Change for Appliance Users 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -2,7 +2,7 @@
 
 Anypoint Runtime Fabric enables you to deploy Mule applications and API proxies to a Kubernetes cluster that you create, configure, and manage.
 
-Runtime Fabric isolates applications by running a separate Mule runtime server per application and supports automated fail-over and horizontal scaling across multiple replicas. You can use Runtime Fabric with managed Kubernetes services like EKS, AKS, and GKE, or with self-managed distributions like Red Hat OpenShift and Rancher. 
+Runtime Fabric isolates applications by running a separate Mule runtime server per application and supports automated fail-over and horizontal scaling across multiple replicas. You can use Runtime Fabric with managed Kubernetes services like EKS, AKS, GKE, and OKE, or with self-managed distributions like Red Hat OpenShift and Rancher. 
 
 Watch the Anypoint Runtime Fabric Product Spotlight video to see a quick overview of Runtime Fabric.
 
@@ -14,7 +14,8 @@ If you work in public clouds and have some level of expertise in managing a Kube
 
 * https://developer.mulesoft.com/tutorials-and-howtos/runtime-fabric/runtime-fabric-aws-elastic-kubernetes-service/[Amazon Elastics Kubernetes Service (EKS)^]
 * https://developer.mulesoft.com/tutorials-and-howtos/runtime-fabric/runtime-fabric-google-kubernetes-engine/[Google Kubernetes Engine (GKE)^]
-* https://developer.mulesoft.com/tutorials-and-howtos/runtime-fabric/runtime-fabric-azure-kubernetes-service/[Microsoft Azure Kubernetes Service (AKS)^] 
+* https://developer.mulesoft.com/tutorials-and-howtos/runtime-fabric/runtime-fabric-azure-kubernetes-service/[Microsoft Azure Kubernetes Service (AKS)^]
+* https://www.oracle.com/cloud/cloud-native/kubernetes-engine/[Oracle Kubernetes Engine (OKE)^]
 * https://aws.amazon.com/rosa/[Red Hat OpenShift Service on AWS (ROSA)^]
 * https://azure.microsoft.com/en-us/products/openshift/[Azure Red Hat OpenShift (ARO)^]
 * https://cloud.google.com/blog/products/gcp/red-hats-openshift-dedicated-now-generally-available-on-google-cloud[Red Hat OpenShift Dedicated on GCP^]
@@ -44,7 +45,7 @@ The Anypoint control plane features, Anypoint CLI, and the Mule Maven Plugin are
 
 [%header%autowidth.spread]
 |===
-|Support of following use-cases |AWS EKS and AWS EKS-A |IBM Openshift Offerings | AKS & GKE | VMWare Tanzu, Alibaba ACK, Rancher
+|Support of following use-cases |AWS EKS and AWS EKS-A |IBM Openshift Offerings | AKS, GKE & OKE | VMWare Tanzu, Alibaba ACK, Rancher
 | Access and use of Anypoint Control Plane including Runtime Manager, Access Management, Anypoint Monitoring, etc.  |Yes |Yes | Yes| Yes
 | Automation toolings such as the Mule Maven Plugin, Runtime Fabric APIs, and Anypoint CLI. |Yes |Yes | Yes | Yes
 | Runtime Fabric functionality support for compatible K8s versions. |Yes |Yes | Yes | Yes
@@ -76,7 +77,7 @@ MuleSoft provides the Runtime Fabric agent, Mule runtime engine (Mule), and othe
 
 ==== Runtime Fabric Core Services
 
-Anypoint Runtime Fabric and its underlying components run as Kubernetes deployment objects in EKS, AKS, GKE, or RedHat OpenShift environments. You manage the objects via Anypoint Platform.
+Anypoint Runtime Fabric and its underlying components run as Kubernetes deployment objects in EKS, AKS, GKE, OKE, or RedHat OpenShift environments. You manage the objects via Anypoint Platform.
 
 Linux-based operating systems are required for all nodes that run Runtime Fabric components in Kubernetes clusters.
 
@@ -162,7 +163,7 @@ The following table lists supported and non-supported features.
 | Support for deploying Mules and API Gateways | Supported 
 | Kubernetes and Docker a| Not included.
 
-Provide your instances of Kubernetes and Docker via Amazon EKS, AKS or GKE clusters. 
+Provide your instances of Kubernetes and Docker via Amazon EKS, AKS, GKE, or OKE clusters. 
 | Installing on any Linux distribution | Supported 
 | Node auto-scaling | Supported using AWS, Azure, Google Cloud, or RedHat OpenShift functionality 
 | External log forwarding | You can set up Log4j to forward logs to external systems. 

--- a/modules/ROOT/pages/install-helm.adoc
+++ b/modules/ROOT/pages/install-helm.adoc
@@ -43,11 +43,12 @@ To install Runtime Fabric with Helm, first create a Runtime Fabric using Runtime
 . From Anypoint Platform, select Runtime Manager.
 . Click *Runtime Fabrics*.
 . Click *Create Runtime Fabric*.
-. Enter the name of the new Runtime Fabric, then select one of the following options:
+. Enter the name of the new Runtime Fabric, then select one of these options:
 
 * Amazon Elastic Kubernetes Service
 * Azure Kubernetes Service
 * Google Kubernetes Engine
+* Oracle Kubernetes Engine
 . Review the Support responsibility disclaimer, and if you agree, click *Accept*.
 . Click Helm.
 

--- a/modules/ROOT/pages/install-helm.adoc
+++ b/modules/ROOT/pages/install-helm.adoc
@@ -1,6 +1,6 @@
 = Installing Runtime Fabric Using Helm
 
-You can use Helm to install Anypoint Runtime Fabric on an Amazon Elastic Kubernetes Service (Amazon EKS), Amazon Elastic Kubernetes Service Anywhere (Amazon EKS-A), Azure Kubernetes Service (AKS), Alibaba Cloud Container Service for Kubernetes (ACK), Google Kubernetes Engine (GKE), Rancher Kubernetes Engine (RKE) or VMware Tanzu Kubernetes Grid installation that you manage.
+You can use Helm to install Anypoint Runtime Fabric on an Amazon Elastic Kubernetes Service (Amazon EKS), Amazon Elastic Kubernetes Service Anywhere (Amazon EKS-A), Azure Kubernetes Service (AKS), Alibaba Cloud Container Service for Kubernetes (ACK), Google Kubernetes Engine (GKE), Oracle Kubernetes Engine (OKE), Rancher Kubernetes Engine (RKE) or VMware Tanzu Kubernetes Grid installation that you manage.
 
 == Steps to Install Runtime Fabric Using Helm
 
@@ -22,7 +22,7 @@ Before installing Anypoint Runtime Fabric in a Kubernetes environment, ensure th
 * xref:install-self-managed-network-configuration.adoc[Configured your network to support Runtime Fabric].
 * Installed and configured your Kubernetes environment as follows:
 +
-** Running an ACK, AKS, EKS, EKS-A, GKE, RKE, or VMware Tanzu Kubernetes environment. Other Kubernetes environments are not supported.
+** Running an ACK, AKS, EKS, EKS-A, GKE, OKE, RKE, or VMware Tanzu Kubernetes environment. Other Kubernetes environments aren't supported.
 ** Running a supported Kubernetes version.
 ** Running an ingress controller to send external requests to applications.
 * Installed Helm 3 or later and have privileged user permissions.

--- a/modules/ROOT/pages/install-self-managed.adoc
+++ b/modules/ROOT/pages/install-self-managed.adoc
@@ -1,6 +1,6 @@
 = Installing Runtime Fabric Using RTFCTL
 
-You can use the Runtime Fabric command line tool, `rtfctl`, to install Anypoint Runtime Fabric on an Amazon Elastic Kubernetes Service (Amazon EKS), Amazon Elastic Kubernetes Service Anywhere (Amazon EKS-A), Azure Kubernetes Service (AKS), Alibaba Cloud Container Service for Kubernetes (ACK), Google Kubernetes Engine (GKE), Rancher Kubernetes Engine (RKE) installation that you manage. 
+You can use the Runtime Fabric command line tool, `rtfctl`, to install Anypoint Runtime Fabric on an Amazon Elastic Kubernetes Service (Amazon EKS), Amazon Elastic Kubernetes Service Anywhere (Amazon EKS-A), Azure Kubernetes Service (AKS), Alibaba Cloud Container Service for Kubernetes (ACK), Google Kubernetes Engine (GKE), Oracle Kubernetes Engine (OKE), Rancher Kubernetes Engine (RKE) installation that you manage. 
 
 [NOTE]
 Runtime Fabric versions 2.2.5 or later that support multiple instances require `rtfctl` version 0.4.1 or later.
@@ -18,7 +18,7 @@ Before installing Anypoint Runtime Fabric in a Kubernetes environment, ensure:
 * You have xref:install-self-managed-network-configuration.adoc[configured your network to support Runtime Fabric]
 * You have installed and configured your Kubernetes environment with:
 +
-** An ACK, AKS, EKS, EKS-A, GKE, or RKE Kubernetes environment. Other Kubernetes environments are not supported.
+** An ACK, AKS, EKS, EKS-A, GKE, OKE, or RKE Kubernetes environment. Other Kubernetes environments aren't supported.
 ** A supported Kubernetes version.
 ** An ingress controller to send external requests to applications.
 * You create your clusters using the latest Runtime Fabric agent version available. If you can't do so, refer to https://help.salesforce.com/s/articleView?id=001117134&type=1[How to Specify the RTF Agent Version in Upgrades^].

--- a/modules/ROOT/pages/install-self-managed.adoc
+++ b/modules/ROOT/pages/install-self-managed.adoc
@@ -73,11 +73,12 @@ To install Runtime Fabric, first create a Runtime Fabric using Runtime Manager. 
 . From Anypoint Platform, select Runtime Manager.
 . Click *Runtime Fabrics*.
 . Click *Create Runtime Fabric*.
-. Enter the name of the new Runtime Fabric, then select one of the following options:
+. Enter the name of the new Runtime Fabric, then select one of these options:
 +
 * Amazon Elastic Kubernetes Service
 * Azure Kubernetes Service
 * Google Kubernetes Engine
+* Oracle Kubernetes Engine
 
 . Click *Next*.
 . Click *rtfctl*.

--- a/modules/ROOT/pages/limitations-self.adoc
+++ b/modules/ROOT/pages/limitations-self.adoc
@@ -56,6 +56,7 @@ Anypoint Runtime Fabric works on any Linux distribution supported by:
 * Amazon EKS Anywhere (EKS-A)
 * Google Kubernetes Engine (GKE)
 * Microsoft Azure Kubernetes Service (AKS)
+* Oracle Kubernetes Engine (OKE)
 * Rancher Kubernetes Engine (RKE2)
 * Red Hat OpenShift
 * VMware Tanzu
@@ -127,7 +128,7 @@ It is common practice for applications deployed on Runtime Fabric to log directl
   
 === External Log Forwarding
 
-Anypoint Runtime Fabric does not forward logs to an external system. You are responsible for installing and managing this configuration. Any external log forwarding agent compatible with your Kubernetes environment running on Amazon EKS, AKS, or GKE can be used. Commonly used log forwarding agents include:
+Anypoint Runtime Fabric doesn't forward logs to an external system. You are responsible for installing and managing this configuration. Any external log forwarding agent compatible with your Kubernetes environment running on Amazon EKS, AKS, GKE, or OKE can be used. Commonly used log forwarding agents include:
 
 * Fluentbit
 

--- a/modules/ROOT/pages/upgrade-helm.adoc
+++ b/modules/ROOT/pages/upgrade-helm.adoc
@@ -1,6 +1,6 @@
 = Upgrading Runtime Fabric Using Helm
 
-You can use Helm to upgrade Anypoint Runtime Fabric on an Amazon Elastic Kubernetes Service (Amazon EKS), Amazon Elastic Kubernetes Service Anywhere (Amazon EKS-A), Azure Kubernetes Service (AKS), or Google Kubernetes Engine (GKE) installation that you manage.
+You can use Helm to upgrade Anypoint Runtime Fabric on an Amazon Elastic Kubernetes Service (Amazon EKS), Amazon Elastic Kubernetes Service Anywhere (Amazon EKS-A), Azure Kubernetes Service (AKS), Google Kubernetes Engine (GKE), or Oracle Kubernetes Engine (OKE) installation that you manage.
 
 Helm upgrades are not available for existing installations that used the `rtfctl` command line tool.
 

--- a/modules/ROOT/pages/upgrade-self-managed.adoc
+++ b/modules/ROOT/pages/upgrade-self-managed.adoc
@@ -1,6 +1,6 @@
 = Upgrading Runtime Fabric Using RTFCTL
 
-You can use the Runtime Fabric command line tool, `rtfctl`, to upgrade Anypoint Runtime Fabric on an Amazon Elastic Kubernetes Service (Amazon EKS), Amazon Elastic Kubernetes Service Anywhere (Amazon EKS-A), Azure Kubernetes Service (AKS) or Google Kubernetes Engine (GKE). 
+You can use the Runtime Fabric command line tool, `rtfctl`, to upgrade Anypoint Runtime Fabric on an Amazon Elastic Kubernetes Service (Amazon EKS), Amazon Elastic Kubernetes Service Anywhere (Amazon EKS-A), Azure Kubernetes Service (AKS), Google Kubernetes Engine (GKE), or Oracle Kubernetes Engine (OKE). 
 
 == About Component Upgrades
 


### PR DESCRIPTION
## Summary
- Documents Oracle Kubernetes Engine (OKE) as a supported managed Kubernetes platform for Runtime Fabric, in the same category as AKS and GKE ([W-23982972](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002iiwUGYAY/view)).
- Adds OKE to the overview supported-platform list (linked to [Oracle Kubernetes Engine](https://www.oracle.com/cloud/cloud-native/kubernetes-engine/)) and to the feature-support table column **AKS, GKE & OKE**.
- Updates the other pages that list supported Kubernetes platforms (requirements, Helm/rtfctl install and upgrade intros, VM/bare-metal migration list, authorized namespaces, log-forwarding environments).

## Requested change vs. what landed

| Ticket request | Status |
|---|---|
| Add OKE on the overview page, same category as AKS/GKE | Added to `index.adoc` public-cloud list with the Oracle OKE URL |
| Add OKE to the feature table, same category as GKE/AKS | Renamed column `AKS & GKE` → `AKS, GKE & OKE` |
| Other pages that list supported Kubernetes platforms | Updated (see files below) |
| Runtime Manager **Create Runtime Fabric** option | Intentionally not added — UI is gated by `rtf_oke` and not confirmed |
| Release notes backdate from 2.11.50 | Not in this PR — RNs live in `docs-release-notes` |

## Style applied
Active voice, contractions in touched sentences (`aren't` / `doesn't`), no new "the following". Matched existing list/table capitalization and reused the existing Helm xref rather than adding a new install page.

## Sources
- GUS [W-23982972](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002iiwUGYAY/view) — the doc request
- Writer confirmation: OKE URL `https://www.oracle.com/cloud/cloud-native/kubernetes-engine/`; OKE belongs in the AKS & GKE column
- Slack DM Ankur Sethi → Kevin, 24 Aug 2026
- GUS W-23384810, W-23649500, W-23973060 — implementing work and `rtf_oke` rollout (flag still in progress)

## Test plan
- [ ] Confirm overview list and feature table render OKE next to AKS/GKE
- [ ] Confirm OKE link opens https://www.oracle.com/cloud/cloud-native/kubernetes-engine/
- [ ] Spot-check Helm and rtfctl install/upgrade intros
- [ ] Confirm Runtime Manager create-option lists were not changed
- [ ] Follow up with a `docs-release-notes` PR to backdate support from 2.11.50 after the RN date is confirmed