### PR TITLE
W-23431158: Point Runtime Fabric HA/DR at Hosting Options hub

### DIFF
--- a/modules/ROOT/pages/rtf-ha-dr.adoc
+++ b/modules/ROOT/pages/rtf-ha-dr.adoc
@@ -12,7 +12,7 @@ You configure HA for your applications separately by running multiple replicas a
 
 You achieve disaster recovery (DR) by backing up the cluster and restoring it after a larger disruption. MuleSoft doesn't back up your data or your cluster configuration; you own cluster backup, restore, and DR.
 
-For an overview of HA and DR across all Mule deployment models, see xref:mule-runtime::hadr-guide.adoc[High Availability and Disaster Recovery].
+For an overview of HA and DR across all Mule deployment models, see xref:hosting-home::hadr-guide.adoc[High Availability and Disaster Recovery].
 
 == High Availability Versus Disaster Recovery
 
@@ -88,7 +88,7 @@ Restore to the same cluster that the control plane lists, and use the same `rtfc
 
 == See Also
 
-* xref:mule-runtime::hadr-guide.adoc[]
+* xref:hosting-home::hadr-guide.adoc[]
 * xref:manage-backup-restore.adoc[]
 * xref:configure-horizontal-autoscaling.adoc[]
 * xref:hardening-runtime-fabric.adoc[]


### PR DESCRIPTION
## Summary
- Retarget Runtime Fabric HA/DR hub xrefs from `mule-runtime::hadr-guide.adoc` to `hosting-home::hadr-guide.adoc`.

## Test plan
- [ ] Intro and See Also links on `rtf-ha-dr.adoc` open the Hosting Options hub
- [ ] Merge after https://github.com/mulesoft/docs-hosting/pull/485 so the hub page exists

Related: W-24010689