### PR TITLE
w-24095325-restart-permissions-kt

### DIFF
--- a/modules/ROOT/pages/restart-applications.adoc
+++ b/modules/ROOT/pages/restart-applications.adoc
@@ -14,10 +14,10 @@ The restart feature is available for Mule applications deployed to Runtime Fabri
 
 == Before You Begin
 
-Before restarting a Mule application, ensure that you have both of these permissions:
+Before restarting a Mule application, ensure that you have one of these permissions:
 
 * *Restart Applications*
-* *Create Applications*
+* *Manage Settings*
 
 To grant the permissions to a user:
 
@@ -26,7 +26,7 @@ To grant the permissions to a user:
 . In the Access Management navigation menu, click *Users*.
 . Click the name of the user to assign permissions to.
 . Click the *Permissions* tab and click *Add permissions*.
-. Select *Restart Applications* or *Create Applications* from the list of permissions and click *Next*.
+. Select *Restart Applications* or *Manage Settings* from the list of permissions and click *Next*.
 +
 image::rtf-restart-permission.png[Restart Applications permission in Access Management]
 


### PR DESCRIPTION
## Summary
- Update required Runtime Manager API restart permissions on `restart-applications.adoc`: drop **Create Applications** and document **Restart Applications** or **Manage Settings**.
- Wording is **one of** these permissions, matching the Runtime Manager role that grants `POST .../actions/restart`.

## Ticket
[W-24095325](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002jqWfZYAU/view) — RTF: update Required Permissions for RTF Application Restart via API

## Requested change vs. what landed

| Ticket request | Status |
|---|---|
| Drop **Create Applications** as required for the restart endpoint | Updated in *Before You Begin* and the grant steps |
| Document **Restart Applications** and **Manage Settings** | Documented as one of these two permissions |
| Restart API steps, curl example, audit log | Already documented — not changed |

## Sources
- GUS W-24095325 — the doc request
- `anypoint-roles-clients` `data/namespaces/runtime-manager/roles.js` (~lines 254–268): role **Restart RTF or CH2 Applications** is extended by CloudHub **Restart Applications** and **Manage Settings**, and grants `POST /organizations/{{org}}/environments/{{envId}}/actions/restart`

## Test plan
- [ ] Confirm *Before You Begin* lists Restart Applications and Manage Settings, not Create Applications
- [ ] Confirm step 6 uses “Restart Applications or Manage Settings”
- [ ] Confirm the `rtf-restart-permission.png` screenshot still matches the Access Management UI
- [ ] Local build / visual check of the restart page